### PR TITLE
Merge a few changes from access-mock which can go out sooner

### DIFF
--- a/server/controllers/analytics-proxy.js
+++ b/server/controllers/analytics-proxy.js
@@ -28,7 +28,7 @@ module.exports = (req, res) => {
 	//			Image tag. This will send a GET request.
 	if(req.method === 'POST') {
 		res.setHeader('Content-Type', 'application/json');
-		res.status(202).json({status: 'ok'});
+		res.status(202).json(data);
 	} else {
 		res.setHeader('Content-Type', 'image/gif');
 		res.status(202).send(gif);

--- a/views/article.html
+++ b/views/article.html
@@ -10,6 +10,7 @@
 		</style>
 		<style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
 		<script async src="https://cdn.ampproject.org/v0.js"></script>
+		<script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
 		<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 		<script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
 		<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>


### PR DESCRIPTION
This merges in the harmless parts of https://github.com/Financial-Times/google-amp/pull/28, adding some more data to analytics log. Using this, we can monitor when `ACCESS_READER_ID` is switched on (by reading `user.amp_reader_id`).