### PR TITLE
Stream links

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -26,6 +26,11 @@ body {
 	@include oTypographyBody;
 }
 
+a:hover {
+	border-bottom-style: dotted;
+	border-bottom-width: 1px;
+}
+
 .article {
 	@include oTypographyBodyWrapper;
 	@include responsiveWidth;
@@ -306,16 +311,18 @@ body {
 .related-content__link {
 	@include oTypographyLink;
 	@include oTypographySans(m);
-	display: block;
 }
 
 .related-content__date {
 	@include oTypographySans(xs);
+	display: block;
+	margin-top: 1em;
 }
 
 .related-content__summary {
 	@include oTypographySans(s);
 	margin: 0;
+	display: block;
 }
 
 .related-content__theme {
@@ -372,11 +379,12 @@ body {
 .more-ons__link {
 	@include oTypographyLink;
 	@include oTypographySans(m);
-	display: block;
 }
 
 .more-ons__date {
 	@include oTypographySans(xs);
+	display: block;
+	margin-top: 0.5em;
 }
 
 .more-ons__image {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -7,6 +7,7 @@ $o-grid-ie8-rules: 'none';
 @import 'o-grid/main';
 
 @include oFontsInclude(MetricWeb, light); // body
+@include oFontsInclude(MetricWeb, bold); // headings
 @include oFontsInclude(FinancierDisplayWeb); // headings
 @include oFontsInclude(FinancierDisplayWeb, $weight: light, $style: italic); // standfirst
 
@@ -63,6 +64,11 @@ body {
 
 .article-dateline {
 	@include oTypographySans(s);
+}
+
+.primary-theme__link.primary-theme__link {
+	color: oColorsGetPaletteColor(claret);
+	@include oTypographySansBold(l);
 }
 
 .main-footer {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -331,6 +331,11 @@ a:hover {
 	margin: 0;
 }
 
+.related-content__theme-link {
+	text-decoration: none;
+	color: inherit;
+}
+
 .more-ons {
 	@include responsiveWidth;
 	margin-top: 40px;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -27,11 +27,11 @@ body {
 
 .article {
 	@include oTypographyBodyWrapper;
-
 	@include responsiveWidth;
-	.article__copyright-notice {
-		@include oTypographySans(s);
-	}
+}
+
+.article__copyright-notice {
+	@include oTypographySans(s);
 }
 
 .article-standfirst {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -69,6 +69,12 @@ a:hover {
 
 .article-dateline {
 	@include oTypographySans(s);
+	margin-bottom: 1em;
+}
+
+.article-author-byline__author.article-author-byline__author {
+	color: oColorsGetPaletteColor(claret);
+	font-weight: bold;
 }
 
 .primary-theme__link.primary-theme__link {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -31,7 +31,7 @@ body {
 	@include responsiveWidth;
 }
 
-.article__copyright-notice {
+.article__copyright-notice.article__copyright-notice {
 	@include oTypographySans(s);
 }
 

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -1,6 +1,7 @@
 const getArticle = require('../lib/getArticle');
 const addStoryPackage = require('../lib/related-content/story-package');
 const addMoreOns = require('../lib/related-content/more-ons');
+const addPrimaryTheme = require('../lib/primary-theme');
 const renderArticle = require('../lib/render-article');
 const transformArticle = require('../lib/transformEsV3Item.js');
 const isFree = require('../lib/article-is-free');
@@ -13,6 +14,7 @@ function getAndRender(uuid, options) {
 		.then(article => Promise.all([
 			addStoryPackage(article, options),
 			addMoreOns(article, options),
+			addPrimaryTheme(article, options),
 		]).then(() => article))
 		.then(data => {
 			data.SOURCE_PORT = options.production ? '' : ':5000';

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -1,0 +1,8 @@
+const fetch = require('node-fetch');
+
+module.exports = (metadatum) => {
+	const streamUrl = `http://www.ft.com/stream/${metadatum.taxonomy}Id/${metadatum.idV1}`;
+
+	return fetch(streamUrl)
+		.then(res => res.status === 200 && streamUrl);
+};

--- a/server/lib/primary-theme.js
+++ b/server/lib/primary-theme.js
@@ -1,16 +1,12 @@
-const fetch = require('node-fetch');
-
-const validateStreamUrl = (url) => fetch(url)
-	.then(res => res.status === 200);
+const getStreamUrl = require('./get-stream-url');
 
 module.exports = (article) => {
 	const primaryTheme = (article.metadata || []).filter(item => !!item.primary)[0];
 	if(!primaryTheme) return;
 
-	const streamUrl = `http://www.ft.com/stream/${primaryTheme.taxonomy}Id/${primaryTheme.idV1}`;
-	return validateStreamUrl(streamUrl)
-		.then(valid => {
-			if(!valid) return;
+	return getStreamUrl(primaryTheme)
+		.then(streamUrl => {
+			if(!streamUrl) return;
 
 			article.primaryTheme = {
 				url: streamUrl,

--- a/server/lib/primary-theme.js
+++ b/server/lib/primary-theme.js
@@ -1,0 +1,21 @@
+const fetch = require('node-fetch');
+
+const validateStreamUrl = (url) => fetch(url)
+	.then(res => res.status === 200);
+
+module.exports = (article) => {
+	const primaryTheme = (article.metadata || []).filter(item => !!item.primary)[0];
+	if(!primaryTheme) return;
+
+	const streamUrl = `http://www.ft.com/stream/${primaryTheme.taxonomy}Id/${primaryTheme.idV1}`;
+	return validateStreamUrl(streamUrl)
+		.then(valid => {
+			if(!valid) return;
+
+			article.primaryTheme = {
+				url: streamUrl,
+				name: primaryTheme.prefLabel,
+			};
+		})
+		.catch(() => {});
+};

--- a/server/lib/related-content/more-ons.js
+++ b/server/lib/related-content/more-ons.js
@@ -2,8 +2,9 @@ const api = require('next-ft-api-client');
 const dateTransform = require('../article-date');
 const sanitizeImage = require('../sanitize-image');
 const moreOnCount = 5;
+const getStreamUrl = require('../get-stream-url');
 
-const getArticles = metadatum => api.search({
+const addArticles = metadatum => api.search({
 	filter: ['metadata.idV1', metadatum.idV1],
 
 		// Fetch twice as many as we need, to allow for deduping
@@ -26,19 +27,22 @@ const getArticles = metadatum => api.search({
 				image: sanitizeImage(article.mainImage),
 			}))
 	)
-	.then(res => ({
-		key: metadatum.idV1,
-		type: metadatum.type,
-		taxonomy: metadatum.taxonomy,
-		title: metadatum.prefLabel,
-		articles: res,
-	}))
-	.catch(e => ({
-		articles: [],
-		error: e,
-	}));
+	.then(articles => {
+		metadatum.articles = articles;
+	})
+	// Ignore errors
+	.catch(e => {
+		metadatum.error = e;
+	});
 
-const addTitle = metadatum => {
+const addStreamUrl = metadatum => getStreamUrl(metadatum)
+	// Ignore errors
+	.catch(() => {})
+	.then(streamUrl => {
+		metadatum.streamUrl = streamUrl;
+	});
+
+const processMetadata = metadatum => {
 	let type;
 
 	switch(metadatum.taxonomy) {
@@ -55,41 +59,51 @@ const addTitle = metadatum => {
 		type = 'on';
 	}
 
-	metadatum.type = `Latest ${type}`;
-	return metadatum;
+	return {
+		articles: metadatum.articles,
+		key: metadatum.idV1,
+		taxonomy: metadatum.taxonomy,
+		theme: {
+			url: metadatum.streamUrl,
+			type: `Latest ${type}`,
+			name: metadatum.prefLabel,
+		},
+	};
 };
 
-
 module.exports = (article, options) => {
-	const promises = article.metadata.filter(metadatum => metadatum.primary)
-		.map(addTitle)
-		.map(getArticles);
+	// Filter only the metadata with a primary taxonomy
+	const moreOns = article.metadata.filter(metadatum => metadatum.primary);
+
+	const promises = []
+		.concat(moreOns.map(addStreamUrl))
+		.concat(moreOns.map(addArticles));
 
 	return Promise.all(promises)
-		.then(moreOns => {
-			moreOns.forEach(moreOn => {
-				if(moreOn.error) {
-					if(options.raven) {
-						options.raven.captureMessage('More-Ons API call failed', {
-							level: 'error',
-							extra: {moreOn},
-						});
+		.then(() => {
+			article.moreOns = moreOns
+				.filter(moreOn => {
+					if(moreOn.error) {
+						if(options.raven) {
+							options.raven.captureMessage('More-Ons API call failed', {
+								level: 'error',
+								extra: {moreOn},
+							});
+						}
+						return false;
 					}
-					return;
-				}
-
-				moreOn.articles = moreOn.articles.filter(item => {
-					if(options.relatedArticleDeduper.indexOf(item.id) >= 0) return false;
-
-					options.relatedArticleDeduper.push(item.id);
 					return true;
 				})
-				.slice(0, moreOnCount);
-			});
+				.filter(moreOn => {
+					moreOn.articles = moreOn.articles.filter(item => {
+						if(options.relatedArticleDeduper.indexOf(item.id) >= 0) return false;
 
-			return moreOns.filter(moreOn => moreOn.articles.length);
-		})
-		.then(moreOns => {
-			article.moreOns = moreOns;
+						options.relatedArticleDeduper.push(item.id);
+						return true;
+					})
+					.slice(0, moreOnCount);
+					return !!moreOn.articles.length;
+				})
+				.map(processMetadata);
 		});
 };

--- a/server/lib/related-content/story-package.js
+++ b/server/lib/related-content/story-package.js
@@ -7,6 +7,7 @@ const formatRelatedContent = (item) => {
 	const primaryTheme = (item.metadata || []).filter(metadatum => !!metadatum.primary)[0];
 
 	return getStreamUrl(primaryTheme)
+		// Ignore errors
 		.catch(() => {})
 		.then(streamUrl => ({
 			date: dateTransform(item.publishedDate, 'related-content__date'),

--- a/server/lib/related-content/story-package.js
+++ b/server/lib/related-content/story-package.js
@@ -1,6 +1,25 @@
 const getArticle = require('../getArticle');
 const dateTransform = require('../article-date');
 const sanitizeImage = require('../sanitize-image');
+const getStreamUrl = require('../get-stream-url');
+
+const formatRelatedContent = (item) => {
+	const primaryTheme = (item.metadata || []).filter(metadatum => !!metadatum.primary)[0];
+
+	return getStreamUrl(primaryTheme)
+		.catch(() => {})
+		.then(streamUrl => ({
+			date: dateTransform(item.publishedDate, 'related-content__date'),
+			id: item.id,
+			title: item.title,
+			image: sanitizeImage(item.mainImage),
+			summary: Array.isArray(item.summaries) ? item.summaries[0] : null,
+			theme: {
+				url: streamUrl,
+				name: primaryTheme.prefLabel,
+			},
+		}));
+};
 
 module.exports = (article, options) => {
 	const getRelated = (article.storyPackage || []).map(related => getArticle(related.id));
@@ -21,18 +40,10 @@ module.exports = (article, options) => {
 				options.relatedArticleDeduper.push(item.id);
 			});
 
-			article.relatedContent = related.map(item => ({
-				date: dateTransform(item.publishedDate, 'related-content__date'),
-				id: item.id,
-				title: item.title,
-				image: sanitizeImage(item.mainImage),
-				summary: Array.isArray(item.summaries) ? item.summaries[0] : null,
-				theme: item.metadata.reduce(
-					(previous, current) => previous || (current.primary && current.prefLabel),
-					null
-				),
-			}));
-
+			return Promise.all(related.map(formatRelatedContent));
+		})
+		.then(related => {
+			article.relatedContent = related;
 			return article;
 		})
 		.catch(() => {});

--- a/server/lib/render-article.js
+++ b/server/lib/render-article.js
@@ -70,4 +70,4 @@ module.exports = (data, options) => promiseAllObj({
 	description: data.summaries ? data.summaries[0] : '',
 	authorList: getAuthors(data),
 	mainImage: getMainImage(data),
-}).then(t => t.template(Object.assign(t, data)));
+}).then(t => t.template(Object.assign(data, t)));

--- a/server/lib/render-article.js
+++ b/server/lib/render-article.js
@@ -40,7 +40,7 @@ const getAuthors = data => {
 		.map(item => item.prefLabel);
 
 	// Somtimes there are no authors in the taxonomy. It's very sad but it's true.
-	return authors.length ? authors.join(', ') : data.byline.replace(/^by\s+/i, '');
+	return authors.length ? authors.join(', ') : (data.byline || '').replace(/^by\s+/i, '');
 };
 
 const getByline = data => {
@@ -57,7 +57,7 @@ const getByline = data => {
 
 	return Promise.all(promises)
 		.then(authors => {
-			let byline = data.byline.replace(/^by\s+/i, '');
+			let byline = (data.byline || '').replace(/^by\s+/i, '');
 
 			authors.filter(author => !!author.streamUrl)
 				.forEach(author => {

--- a/server/lib/render-article.js
+++ b/server/lib/render-article.js
@@ -6,6 +6,7 @@ const promisify = require('@quarterto/promisify');
 const glob = promisify(require('glob'));
 const cacheIf = require('@quarterto/cache-if');
 const promiseAllObj = require('@quarterto/promise-all-object');
+const getStreamUrl = require('./get-stream-url');
 
 const cssPath = path.resolve('css');
 const viewsPath = path.resolve('views');
@@ -35,12 +36,38 @@ const getPartials = precompiled => cacheIf(() => precompiled, applyPartials);
 
 const getAuthors = data => {
 	const authors = data.metadata
-				.filter(item => !!(item.taxonomy && item.taxonomy === 'authors'))
-				.map(item => item.prefLabel)
-				.join(', ');
+		.filter(item => !!(item.taxonomy && item.taxonomy === 'authors'))
+		.map(item => item.prefLabel);
 
 	// Somtimes there are no authors in the taxonomy. It's very sad but it's true.
-	return authors === '' ? data.byline : authors;
+	return authors.length ? authors.join(', ') : data.byline.replace(/^by\s+/i, '');
+};
+
+const getByline = data => {
+	const promises = data.metadata
+		.filter(item => !!(item.taxonomy && item.taxonomy === 'authors'))
+		.map(author => getStreamUrl(author)
+			// Ignore errors
+			.catch(() => {})
+			.then(streamUrl => {
+				author.streamUrl = streamUrl;
+				return author;
+			})
+		);
+
+	return Promise.all(promises)
+		.then(authors => {
+			let byline = data.byline.replace(/^by\s+/i, '');
+
+			authors.filter(author => !!author.streamUrl)
+				.forEach(author => {
+					byline = byline.replace(author.prefLabel,
+						'<a class="article-author-byline__author"' +
+						` href="${author.streamUrl}">${author.prefLabel}</a>`
+					);
+				});
+			return byline;
+		});
 };
 
 const getMainImage = data => {
@@ -69,5 +96,6 @@ module.exports = (data, options) => promiseAllObj({
 	nikkeiSvg: fs.readFile(`${staticPath}/nikkei-logo.svg`, 'utf8'),
 	description: data.summaries ? data.summaries[0] : '',
 	authorList: getAuthors(data),
+	byline: getByline(data),
 	mainImage: getMainImage(data),
 }).then(t => t.template(Object.assign(data, t)));

--- a/views/article.html
+++ b/views/article.html
@@ -67,6 +67,9 @@
 		<main role="main">
 			<article class="article">
 				<header class="article-header">
+					{{#if primaryTheme}}
+						<h2 class="primary-theme"><a href="{{{primaryTheme.url}}}" class="primary-theme__link">{{{primaryTheme.name}}}</a></h2>
+					{{/if}}
 					<h1 itemprop="headline">{{title}}</h1>
 					{{{displaySummary}}}
 					{{{mainImageHtml}}}

--- a/views/article.html
+++ b/views/article.html
@@ -101,7 +101,7 @@
 					<li class="related-content__story related-content__lead-story">
 						<div class="related-content__container">
 							<div class="related-content__content">
-								{{#if theme}}<h3 class="related-content__theme">{{{theme}}}</h3>{{/if}}
+								{{#if theme}}<h3 class="related-content__theme">{{#if theme.url}}<a class="related-content__theme-link" href="{{{theme.url}}}">{{/if}}{{theme.name}}{{#if theme.url}}</a>{{/if}}</h3>{{/if}}
 								<a class="related-content__link" href="http://www.ft.com/content/{{{id}}}">{{{title}}}</a>
 								<p class="related-content__summary">{{{summary}}}</p>
 								{{{date}}}
@@ -114,7 +114,7 @@
 					{{/if}}{{/if}}
 					<li class="related-content__story{{#if @first}}{{#if image}} related-content__lead-story-alternate{{/if}}{{/if}}">
 						<div class="related-content__container">
-							{{#if theme}}<h3 class="related-content__theme">{{{theme}}}</h3>{{/if}}
+							{{#if theme}}<h3 class="related-content__theme">{{#if theme.url}}<a class="related-content__theme-link" href="{{{theme.url}}}">{{/if}}{{theme.name}}{{#if theme.url}}</a>{{/if}}</h3>{{/if}}
 							<a class="related-content__link" href="http://www.ft.com/content/{{{id}}}">{{{title}}}</a>
 							<p class="related-content__summary">{{{summary}}}</p>
 							{{{date}}}

--- a/views/article.html
+++ b/views/article.html
@@ -76,6 +76,7 @@
 
 					<div class="article-dateline">
 						{{{displayDate}}}
+						{{#if byline}}
 						<span class="article-author">
 							<span class="article-author-byline">
 								by
@@ -84,6 +85,7 @@
 								</span>
 							</span>
 						</span>
+						{{/if}}
 					</div>
 				</header>
 

--- a/views/article.html
+++ b/views/article.html
@@ -80,7 +80,7 @@
 							<span class="article-author-byline">
 								by
 								<span itemscope itemtype="http://schema.org/Person" itemprop="author">
-									{{byline}}
+									{{{byline}}}
 								</span>
 							</span>
 						</span>

--- a/views/article.html
+++ b/views/article.html
@@ -132,9 +132,9 @@
 					<li class="more-ons__item">
 						<div class="more-ons__item-wrapper">
 							<div class="more-ons__type">
-								<h2 class="more-ons__type-text c-box__title-text">{{{type}}}</h2>
+								<h2 class="more-ons__type-text c-box__title-text">{{theme.type}}</h2>
 							</div>
-							<h2 class="more-ons__header">{{{title}}}</h2>
+							<h2 class="more-ons__header">{{#if theme.url}}<a class="related-content__theme-link" href="{{{theme.url}}}">{{/if}}{{theme.name}}{{#if theme.url}}</a>{{/if}}</h2>
 							<ul class="more-ons__stories">
 								{{#each articles}}
 								<li class="more-ons__story">


### PR DESCRIPTION
Clickable primary theme for articles:
<img width="488" alt="screenshot 2016-03-01 19 09 20" src="https://cloud.githubusercontent.com/assets/84737/13438505/35586e92-dfe1-11e5-8d65-26dd9dfd96ce.png">
and story packages:
<img width="168" alt="screenshot 2016-03-01 19 09 40" src="https://cloud.githubusercontent.com/assets/84737/13438512/3e1bb200-dfe1-11e5-8d80-6fd3f40ec18e.png">
and more-ons:
<img width="191" alt="screenshot 2016-03-01 19 09 45" src="https://cloud.githubusercontent.com/assets/84737/13438518/468e4704-dfe1-11e5-97bd-0aafa899cf04.png">

This PR also includes stream links for any authors mentioned in metadata, although currently, none of them correctly redirect to vanity URLs on FT.com, so they won't appear until that's fixed.
<img width="514" alt="screenshot 2016-03-01 19 56 08" src="https://cloud.githubusercontent.com/assets/84737/13440006/f2d52be4-dfe7-11e5-93cf-ebff1bc70832.png">

