### PR TITLE
Correct order for Object.assign

### DIFF
--- a/server/lib/render-article.js
+++ b/server/lib/render-article.js
@@ -70,4 +70,4 @@ module.exports = (data, options) => promiseAllObj({
 	description: data.summaries ? data.summaries[0] : '',
 	authorList: getAuthors(data),
 	mainImage: getMainImage(data),
-}).then(t => t.template(Object.assign(t, data)));
+}).then(t => t.template(Object.assign(data, t)));


### PR DESCRIPTION
It's kinda cool that this worked for so long! The only key in common is actually `mainImage`, and this explains why the Google carousel listings have weird images sometimes - it's because the response from the `getMainImage()` routine was being throw away.