### PR TITLE
Keep font-sizes somewhat proportional even at smallest sizes

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -28,18 +28,20 @@ $border-divider: 1px solid oColorsGetPaletteColor(pink-tint3);
 	@return $px * 100vh / $vh;
 }
 
-@mixin responsiveType($size, $min: 18px, $max: 0) {
+@mixin responsiveType($size, $min: 14px, $max: 0) {
 	font-size: $size;
+	$min-size: $min + ($size / 1vh);
+	$max-size: $max + ($size / 1vh);
 
 	@if $min != 0 {
-		@media (max-height: pxAndVhToViewport($size, $min)) {
-			font-size: $min;
+		@media (max-height: pxAndVhToViewport($size, $min-size)) {
+			font-size: $min-size;
 		}
 	}
 
 	@if $max != 0 {
-		@media (min-height: pxAndVhToViewport($size, $max)) {
-			font-size: $max;
+		@media (min-height: pxAndVhToViewport($size, $max-size)) {
+			font-size: $max-size;
 		}
 	}
 }


### PR DESCRIPTION
@quarterto What d'ya think about this? It's a bit hacky, but I wanted the headline font sizes to retain a touch of proportionality even at the smallest size. This is apparent on an iPhone when viewed in the Google carousel, as there's reduced vertical viewport height. This PR means that the headline remains slightly larger than the standfirst.