### PR TITLE
don't follow redirects in get-stream-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@quarterto/assert-env": "^1.1.0",
     "@quarterto/cache-if": "^1.1.0",
+    "@quarterto/fetch-head": "^1.0.0",
     "@quarterto/promise-all-object": "^1.1.0",
     "@quarterto/promisify": "^1.0.0",
     "autoprefixer": "^6.3.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@quarterto/assert-env": "^1.1.0",
     "@quarterto/cache-if": "^1.1.0",
-    "@quarterto/fetch-head": "^1.0.0",
+    "@quarterto/fetch-head": "^1.3.0",
     "@quarterto/promise-all-object": "^1.1.0",
     "@quarterto/promisify": "^1.0.0",
     "autoprefixer": "^6.3.3",

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -43,7 +43,7 @@ function getAndRender(uuid, options) {
 			data.accessMocked = !!options.accessMock;
 			return data;
 		})
-		.then(data => renderArticle(data, {precompiled: options.production}));
+		.then(data => renderArticle(data, options));
 }
 
 module.exports = (req, res, next) => {
@@ -51,6 +51,8 @@ module.exports = (req, res, next) => {
 		production: req.app.get('env') === 'production',
 		raven: req.raven,
 		host: req.get('host'),
+		ip: req.ip,
+		ua: req.get('User-Agent'),
 		relatedArticleDeduper: [req.params.uuid],
 		accessMock: req.cookies.amp_access_mock,
 	})

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -5,5 +5,5 @@ module.exports = (metadatum) => {
 	const streamUrl = `http://www.ft.com/stream/${metadatum.taxonomy}Id/${metadatum.idV1}`;
 
 	return fetchHead(streamUrl)
-		.then(res => res.status !== 404 && streamUrl, e => {console.error(e); throw e});
+		.then(res => res.status >= 200 && res.status < 400 && streamUrl);
 };

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -6,6 +6,6 @@ module.exports = (metadatum) => {
 
 	// NB. Node 5 encounters a ZLib decompression issue if a HEAD request
 	// returns GZip content. See https://github.com/bitinn/node-fetch/issues/45.
-	return fetch(streamUrl, {method: 'HEAD', compress: false})
-		.then(res => res.status === 200 && streamUrl);
+	return fetch(streamUrl, {method: 'HEAD', compress: false, follow: 0})
+		.then(res => res.status !== 404 && streamUrl);
 };

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -1,9 +1,18 @@
 'use strict';
 const fetchHead = require('./wrap-fetch.js')('get-stream-url', require('@quarterto/fetch-head'));
 
-module.exports = (metadatum) => {
+module.exports = (metadatum, options) => {
 	const streamUrl = `http://www.ft.com/stream/${metadatum.taxonomy}Id/${metadatum.idV1}`;
+	const headers = {};
 
-	return fetchHead(streamUrl)
+	// Set User-Agent (to avoid Akamai blocking the request), and client IP
+	// to avoid rate-limiting by IP.
+	if(options.ua) headers['user-agent'] = options.ua;
+	if(options.ip) {
+		headers['x-forwarded-for'] = options.ip;
+		headers['true-client-ip'] = options.ip;
+	}
+
+	return fetchHead(streamUrl, {headers})
 		.then(res => res.status >= 200 && res.status < 400 && streamUrl);
 };

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -7,5 +7,14 @@ module.exports = (metadatum) => {
 	// NB. Node 5 encounters a ZLib decompression issue if a HEAD request
 	// returns GZip content. See https://github.com/bitinn/node-fetch/issues/45.
 	return fetch(streamUrl, {method: 'HEAD', compress: false, follow: 0})
-		.then(res => res.status !== 404 && streamUrl);
+	.catch(e => {
+		// Don't follow the redirect, but assume that if a redirect code is given
+		//  (see Fetch.prototype.isRedirect), the falcon redirect service has
+		//  found a corresponding URL on FT.com, and streamUrl can be served.
+		if(/maximum redirect reached/.test(e.message)) {
+			return streamUrl;
+		}
+
+		throw e;
+	});
 };

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -1,20 +1,9 @@
 'use strict';
-const fetch = require('./wrap-fetch.js')('get-stream-url', require('node-fetch'));
+const fetchHead = require('./wrap-fetch.js')('get-stream-url', require('@quarterto/fetch-head'));
 
 module.exports = (metadatum) => {
 	const streamUrl = `http://www.ft.com/stream/${metadatum.taxonomy}Id/${metadatum.idV1}`;
 
-	// NB. Node 5 encounters a ZLib decompression issue if a HEAD request
-	// returns GZip content. See https://github.com/bitinn/node-fetch/issues/45.
-	return fetch(streamUrl, {method: 'HEAD', compress: false, follow: 0})
-	.catch(e => {
-		// Don't follow the redirect, but assume that if a redirect code is given
-		//  (see Fetch.prototype.isRedirect), the falcon redirect service has
-		//  found a corresponding URL on FT.com, and streamUrl can be served.
-		if(/maximum redirect reached/.test(e.message)) {
-			return streamUrl;
-		}
-
-		throw e;
-	});
+	return fetchHead(streamUrl)
+		.then(res => res.status !== 404 && streamUrl, e => {console.error(e); throw e});
 };

--- a/server/lib/primary-theme.js
+++ b/server/lib/primary-theme.js
@@ -1,11 +1,11 @@
 'use strict';
 const getStreamUrl = require('./get-stream-url');
 
-module.exports = (article) => {
+module.exports = (article, options) => {
 	const primaryTheme = (article.metadata || []).filter(item => !!item.primary)[0];
 	if(!primaryTheme) return;
 
-	return getStreamUrl(primaryTheme)
+	return getStreamUrl(primaryTheme, options)
 		.then(streamUrl => {
 			if(!streamUrl) return;
 

--- a/server/lib/related-content/more-ons.js
+++ b/server/lib/related-content/more-ons.js
@@ -38,7 +38,7 @@ const addArticles = metadatum => apiSearch({
 		metadatum.error = e;
 	});
 
-const addStreamUrl = metadatum => getStreamUrl(metadatum)
+const addStreamUrl = (options, metadatum) => getStreamUrl(metadatum, options)
 	// Ignore errors
 	.catch(() => {})
 	.then(streamUrl => {
@@ -79,7 +79,7 @@ module.exports = (article, options) => {
 	const moreOns = article.metadata.filter(metadatum => metadatum.primary);
 
 	const promises = []
-		.concat(moreOns.map(addStreamUrl))
+		.concat(moreOns.map(addStreamUrl.bind(null, options)))
 		.concat(moreOns.map(addArticles));
 
 	return Promise.all(promises)

--- a/server/lib/related-content/story-package.js
+++ b/server/lib/related-content/story-package.js
@@ -4,10 +4,10 @@ const dateTransform = require('../article-date');
 const sanitizeImage = require('../sanitize-image');
 const getStreamUrl = require('../get-stream-url');
 
-const formatRelatedContent = (item) => {
+const formatRelatedContent = (options, item) => {
 	const primaryTheme = (item.metadata || []).filter(metadatum => !!metadatum.primary)[0];
 
-	return getStreamUrl(primaryTheme)
+	return getStreamUrl(primaryTheme, options)
 		// Ignore errors
 		.catch(() => {})
 		.then(streamUrl => ({
@@ -42,7 +42,7 @@ module.exports = (article, options) => {
 				options.relatedArticleDeduper.push(item.id);
 			});
 
-			return Promise.all(related.map(formatRelatedContent));
+			return Promise.all(related.map(formatRelatedContent.bind(null, options)));
 		})
 		.then(related => {
 			article.relatedContent = related;

--- a/server/lib/render-article.js
+++ b/server/lib/render-article.js
@@ -44,10 +44,10 @@ const getAuthors = data => {
 	return authors.length ? authors.join(', ') : (data.byline || '').replace(/^by\s+/i, '');
 };
 
-const getByline = data => {
+const getByline = (data, options) => {
 	const promises = data.metadata
 		.filter(item => !!(item.taxonomy && item.taxonomy === 'authors'))
-		.map(author => getStreamUrl(author)
+		.map(author => getStreamUrl(author, options)
 			// Ignore errors
 			.catch(() => {})
 			.then(streamUrl => {
@@ -90,13 +90,13 @@ const getMainImage = data => {
 };
 
 module.exports = (data, options) => promiseAllObj({
-	template: getTemplate(options.precompiled),
-	partials: getPartials(options.precompiled),
-	css: getCss(options.precompiled),
+	template: getTemplate(options.production),
+	partials: getPartials(options.production),
+	css: getCss(options.production),
 	ftSvg: fs.readFile(`${staticPath}/ft-logo.svg`, 'utf8'),
 	nikkeiSvg: fs.readFile(`${staticPath}/nikkei-logo.svg`, 'utf8'),
 	description: data.summaries ? data.summaries[0] : '',
 	authorList: getAuthors(data),
-	byline: getByline(data),
+	byline: getByline(data, options),
 	mainImage: getMainImage(data),
 }).then(t => t.template(Object.assign(data, t)));


### PR DESCRIPTION
by default, node-fetch follows redirects. ft.com immediately returns a 302 for stream pages that exist, so node-fetch redirects and loads the actual topic page.