### PR TITLE
group related instrumented fetches (i.e storypackage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lintspaces-cli": "^0.1.1",
     "lodash.padend": "^4.2.0",
     "lodash.padstart": "^4.2.0",
-    "midna": "^1.0.0",
+    "midna": "^1.3.0",
     "nodemon": "^1.8.1",
     "prog-rock": "^1.2.1"
   }

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -13,6 +13,6 @@ module.exports = (metadatum, options) => {
 		headers['true-client-ip'] = options.ip;
 	}
 
-	return fetchHead(streamUrl, {headers})
+	return fetchHead(streamUrl, {headers, _wrappedFetchGroup: options._wrappedFetchGroup})
 		.then(res => res.status >= 200 && res.status < 400 && streamUrl);
 };

--- a/server/lib/getArticle.js
+++ b/server/lib/getArticle.js
@@ -3,5 +3,5 @@ const elasticSearchUrl = process.env.ELASTIC_SEARCH_URL;
 const signedFetch = require('./wrap-fetch.js')('getArticle', require('signed-aws-es-fetch'));
 const index = 'v3_api_v2';
 
-module.exports = uuid => signedFetch(`https://${elasticSearchUrl}/${index}/item/${uuid}`)
+module.exports = (uuid, options) => signedFetch(`https://${elasticSearchUrl}/${index}/item/${uuid}`, options)
 	.then(response => response.json());

--- a/server/lib/related-content/story-package.js
+++ b/server/lib/related-content/story-package.js
@@ -6,6 +6,7 @@ const getStreamUrl = require('../get-stream-url');
 
 const formatRelatedContent = (options, item) => {
 	const primaryTheme = (item.metadata || []).filter(metadatum => !!metadatum.primary)[0];
+	options._wrappedFetchGroup = `story-package-${item.id}`;
 
 	return getStreamUrl(primaryTheme, options)
 		// Ignore errors
@@ -24,7 +25,10 @@ const formatRelatedContent = (options, item) => {
 };
 
 module.exports = (article, options) => {
-	const getRelated = (article.storyPackage || []).map(related => getArticle(related.id));
+	const getRelated = (article.storyPackage || []).map(related => getArticle(related.id, {
+		_wrappedFetchGroup: `story-package-${related.id}`,
+	}));
+
 	return Promise.all(getRelated)
 		.catch(e => {
 			if(options.raven) {

--- a/server/lib/wrap-fetch.js
+++ b/server/lib/wrap-fetch.js
@@ -2,9 +2,9 @@
 
 const log = [];
 
-module.exports = (tag, fetch) => process.env.NODE_ENV !== 'instrument' ? fetch : function wrappedFetch(url) {
+module.exports = (tag, fetch) => process.env.NODE_ENV !== 'instrument' ? fetch : function wrappedFetch(url, options) {
 	const label = url.filter ? url.filter[1] : url;
-	const item = {tag, label, start: process.hrtime()};
+	const item = {tag, label, start: process.hrtime(), group: options && options._wrappedFetchGroup};
 
 	return fetch.apply(null, arguments).then(r => {
 		item.end = process.hrtime();


### PR DESCRIPTION
![screenshot 2016-03-08 13 46 46](https://cloud.githubusercontent.com/assets/631757/13603322/516389fc-e534-11e5-8e55-6d997c9a43f9.png)

@georgecrawford this does a good job of showing why some `get-stream-urls` start later: they're caused by the storypackage getarticle requests (which we knew already, but it's good to see it)