### PR TITLE
eliminate obs redirect

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,4 +1,4 @@
-$o-fonts-path: '//h2.ft.com/build/files/o-fonts-assets@1.3.0/';
+$o-fonts-path: '//h2.ft.com/build/v2/files/o-fonts-assets@1.3.0/';
 $o-grid-ie8-rules: 'none';
 
 @import 'o-colors/main';


### PR DESCRIPTION
@quarterto @georgecrawford 

Hiya - I'm fixing calls to the build service in next and noticed this. 

`https://h2.ft.com/build/files/o-fonts-assets@1.3.0/MetricWeb-Light.woff`

will get a 404, but 

`https://h2.ft.com/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Light.woff`

should work.