### PR TITLE
Output interactive graphics in valid AMP HTML

### DIFF
--- a/scripts/test-uuids.sh
+++ b/scripts/test-uuids.sh
@@ -29,6 +29,7 @@ export TEST_UUIDS=(
 	"e5fbd11a-d3ef-11e5-969e-9d801cf5e15b"
 	"b4284269-2951-3169-ab98-88c184da5e88"
 	"c0e910c4-d005-11e5-831d-09f7778e7377" # lunch with the ft
+	"f89bc888-8029-11e2-96ba-00144feabdc0" # Interactive graphic (HTTP)
 
 	# QA Test List
 	"94e97eee-ce9a-11e5-831d-09f7778e7377"

--- a/server/stylesheets/interactive-graphics.xsl
+++ b/server/stylesheets/interactive-graphics.xsl
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
+	<xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'"/>
+	<xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
 	<xsl:template match="a[@data-asset-type='interactive-graphic']">
-		<iframe class="article__interactive" src="{@href}" width="{@data-width}" height="{@data-height}" scrolling="no"></iframe>
+		<xsl:if test="translate(substring(@href, 0, 6), $uppercase, $lowercase) = 'https'">
+
+			<amp-iframe
+				src="{@href}"
+				sandbox="allow-scripts allow-same-origin"
+				layout="responsive"
+				frameborder="0"
+				width="{@data-width}" height="{@data-height}">
+			</amp-iframe>
+
+		</xsl:if>
 	</xsl:template>
 
 </xsl:stylesheet>

--- a/views/article.html
+++ b/views/article.html
@@ -20,6 +20,7 @@
 		<script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
 		<script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
 		<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+		<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
 
 		<script id="amp-access" type="application/json">
 		{


### PR DESCRIPTION
This applies to interactive graphics that are displayed using iframes.
If the graphic source is insecure then we have to simply remove it. For
graphics which are served over HTTPS, we create an amp-iframe.

There's currently no way to test HTTPS iframes automatically, IG was
unable to find an article which used them. Regardless, this is an
improvement on the current behaviour for any existing articles which
have iframe-embedded interactive graphics.