### PR TITLE
Only check stream URLs when required by env

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
 		"SPOOR_API_KEY": {"required": false},
 		"API_V1_KEY": {"required": false},
 		"LIGHT_SIGNUP_URL": {"required": false},
-		"ENABLE_LIGHT_SIGNUP": {"required": false}
+		"ENABLE_LIGHT_SIGNUP": {"required": false},
+		"VERIFY_STREAM_URLS": {"required": false}
 	},
 	"addons": [
 		"papertrail"

--- a/server/lib/get-stream-url.js
+++ b/server/lib/get-stream-url.js
@@ -5,6 +5,11 @@ const fetchHead = require('./wrap-fetch')(require('@quarterto/fetch-head'), {
 
 module.exports = (metadatum, options) => {
 	const streamUrl = `http://www.ft.com/stream/${metadatum.taxonomy}Id/${metadatum.idV1}`;
+
+	if(process.env.VERIFY_STREAM_URLS !== 'true') {
+		return Promise.resolve(streamUrl);
+	}
+
 	const headers = {};
 
 	// Set User-Agent (to avoid Akamai blocking the request), and client IP


### PR DESCRIPTION
I've set `VERIFY_STREAM_URLS = false` on this review app only, so we can see how this behaves in staging. Note that we should wait for fixed AWS keys before testing and releasing this.