### PR TITLE
Fix for images between 480-599px wide

### DIFF
--- a/server/lib/external-images.js
+++ b/server/lib/external-images.js
@@ -61,8 +61,9 @@ module.exports = function externalImages($, options) {
 					});
 
 					if(!isAside && width < 600) {
-						// don't stretch narrow inline images to page width
-						$el.attr('layout', 'fixed');
+						// don't stretch narrow inline images to page width, and don't
+						// allow images between 480-599px to break out of .main column
+						$el.parents('figure').css('max-width', `${width}px`);
 					}
 				});
 		}


### PR DESCRIPTION
Example narrow image: http://amp.ft.com/content/589ea5f2-41ce-11e6-9b66-0712b3873ae1 (the review stars).
Example image between 480-599px: http://amp.ft.com/content/735eb4c8-998f-11e5-9228-87e603d47bdc (captioned "Syria air strikes"), which breaks layout on smallscreen devices in prod