### PR TITLE
AB testing (not ready for merge)

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -22,6 +22,22 @@ body {
 	@include oColorsFor(page, background);
 }
 
+body[amp-x-experiment="bucket1"] {
+	background-color: red;
+}
+
+body[amp-x-experiment="bucket2"] {
+	background-color: green;
+}
+
+body[amp-x-experiment="bucket3"] {
+	background-color: blue;
+}
+
+body:not([amp-x-experiment]) {
+	background-color: grey;
+}
+
 .main-wrapper {
 	display: flex;
 	flex-direction: column;

--- a/server/controllers/analytics-config.js
+++ b/server/controllers/analytics-config.js
@@ -69,6 +69,9 @@ module.exports = (req, res, next) => {
 		},
 		user: {
 			ft_session: 'AUTHDATA(session)',
+			ab: {
+				experiment: 'VARIANT(experiment)',
+			},
 		},
 		time: {
 			amp_timestamp: '${timestamp}',

--- a/views/article.html
+++ b/views/article.html
@@ -21,6 +21,7 @@
 		<script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
 		<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 		<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+		<script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
 		{{#if enableSidebarMenu}}
 		<script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
 		<script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
@@ -71,6 +72,24 @@
 		</script>
 	</head>
 	<body>
+
+		<!-- // @nocommit -->
+		<amp-experiment>
+			<script type="application/json">
+				{
+					aExperiment: {
+						sticky: true,
+						consentNotificationId: "consent-notif",
+						variants: {
+							treatment1: 12.5,
+							treatment2: 12.5,
+							treatment3: 25.0,
+						},
+					},
+				}
+			</script>
+		</amp-experiment>
+
 		<amp-analytics config="//SOURCE_HOSTNAME{{SOURCE_PORT}}/analytics/config.json">
 			<script type="application/json">
 			{

--- a/views/article.html
+++ b/views/article.html
@@ -73,19 +73,17 @@
 	</head>
 	<body>
 
-		<!-- // @nocommit -->
 		<amp-experiment>
 			<script type="application/json">
 				{
-					aExperiment: {
-						sticky: true,
-						consentNotificationId: "consent-notif",
-						variants: {
-							treatment1: 12.5,
-							treatment2: 12.5,
-							treatment3: 25.0,
-						},
-					},
+					"experiment": {
+						"sticky": false,
+						"variants": {
+							"bucket1": 25,
+							"bucket2": 25,
+							"bucket3": 25
+						}
+					}
 				}
 			</script>
 		</amp-experiment>


### PR DESCRIPTION
**Not ready for merge**

Points of interest:

- requires the `AMP Experiment` experiment to be toggled on in the browser (see https://cdn.ampproject.org/experiments.html)
- currently set to 'non-sticky', so user will receive a new bucket for each visit. 'sticky' is probably what we want for our tests
- 3 buckets, each with 25% of traffic; the remainder is assigned to 'none'
- tracked as: `user.ab.experiment: "bucket1"`, etc
- force a particular bucket by appending `#amp-x-experiment=bucket1` to the URL