### PR TITLE
Convert targeting param to string

### DIFF
--- a/views/ads-iframe.html
+++ b/views/ads-iframe.html
@@ -41,7 +41,7 @@
 								pos: 'mid',
 							};
 							targeting.forEach(function(target) {
-								config.targeting[target.key] = target.value
+								config.targeting[target.key] = target.value.toString();
 							});
 
 							var kruxFn = Krux.amp.withConfid('KHUSeE3x')


### PR DESCRIPTION
Values that are booleans get skipped out of the ad call, so convert them to strings.

@quarterto @VladDubrovskis 