### PR TITLE
Commented-out but working AB test code

### DIFF
--- a/scss/abTest.scss
+++ b/scss/abTest.scss
@@ -1,0 +1,10 @@
+// See /views/partials/abTest.html and /server/controllers/analytics-config.js
+
+/*
+	body[amp-x-background-color-test=yellow] {
+		background-color: yellow;
+	}
+	body[amp-x-background-color-test=green] {
+		background-color: green;
+	}
+*/

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -14,6 +14,8 @@
 @import 'footer';
 @import 'social';
 
+@import 'abTest';
+
 @import 'hacks';
 
 @include oFontsInclude(MetricWeb, regular); // body

--- a/server/controllers/analytics-config.js
+++ b/server/controllers/analytics-config.js
@@ -68,6 +68,13 @@ module.exports = (req, res, next) => {
 		},
 		user: {
 			ft_session: 'AUTHDATA(session)',
+
+/*
+			// See /views/partials/abTest.html and /scss/abTest.scss
+			ab: {
+				'background-color-test': 'VARIANT(background-color-test)',
+			},
+*/
 		},
 		time: {
 			amp_timestamp: '${timestamp}',

--- a/views/article.html
+++ b/views/article.html
@@ -22,6 +22,7 @@
 		<script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
 		<script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
 		<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+		<script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
 		{{#if enableSocialShare}}
 		<script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
 		{{/if}}
@@ -75,6 +76,8 @@
 		</script>
 	</head>
 	<body>
+		{{> abTest}}
+
 		<amp-analytics config="//SOURCE_HOSTNAME{{SOURCE_PORT}}/analytics/config.json">
 			<script type="application/json">
 			{

--- a/views/partials/abTest.html
+++ b/views/partials/abTest.html
@@ -1,0 +1,17 @@
+<!-- See /server/controllers/analytics-config.js and /scss/abTest.scss -->
+
+<!--
+	<amp-experiment>
+		<script type="application/json">
+			{
+				"background-color-test": {
+					"sticky": false,
+					"variants": {
+						"yellow": 33,
+						"green": 33
+					}
+				}
+			}
+		</script>
+	</amp-experiment>
+-->


### PR DESCRIPTION
Points of interest:

- currently set to 'non-sticky', so user will receive a new bucket for each visit. 'sticky' is probably what we want for our tests
- Any remainder from the bucket % total is assigned to 'none' in analytics
- tracked as: `user.ab.background-color-test: "yellow"`, etc
- force a particular bucket by appending `#amp-x-background-color-test=yellow` to the URL