### PR TITLE
Fix margin on slideshow title

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -552,6 +552,7 @@ body {
 .slideshow__title.slideshow__title {
 	@include oTypographySans(m);
 	padding: 10px;
+	margin: 0;
 }
 
 .slideshow__caption.slideshow__caption {


### PR DESCRIPTION
before:
![screenshot 2016-09-20 10 32 16](https://cloud.githubusercontent.com/assets/84737/18665217/0d8f54ca-7f1e-11e6-973a-ceb719a8ef83.png)
after:
![screenshot 2016-09-20 10 36 24](https://cloud.githubusercontent.com/assets/84737/18665223/15c01e2c-7f1e-11e6-9b46-7f5a8b5e8e63.png)

