### PR TITLE
AT-627: Fix some Google search console errors

### DIFF
--- a/server/lib/cheerio-transform.js
+++ b/server/lib/cheerio-transform.js
@@ -10,6 +10,7 @@ const removeStyleAttributes = require('./transforms/remove-styles');
 const replaceFtConceptTags = require('./transforms/ft-concept');
 const insertAd = require('./transforms/insert-ad');
 const linkAnalytics = require('./transforms/link-analytics');
+const removeInvalidLinks = require('./transforms/remove-invalid-links');
 
 module.exports = function run(body, flags) {
 	body = replaceEllipses(body);
@@ -26,6 +27,7 @@ module.exports = function run(body, flags) {
 		lightSignup,
 		replaceFtConceptTags,
 		linkAnalytics,
+		removeInvalidLinks,
 	].map(transform => transform($, flags)))
 		.then(() => $);
 };

--- a/server/lib/report-error.js
+++ b/server/lib/report-error.js
@@ -19,6 +19,6 @@ module.exports = function reportError(raven, error, options) {
 			level: options.getErrorLevel(error),
 		}, options));
 	} else {
-		console.error(error.stack || error.message || error.toString());
+		console.error(error.stack || error.message || error.toString(), options);
 	}
 };

--- a/server/lib/transforms/link-analytics.js
+++ b/server/lib/transforms/link-analytics.js
@@ -1,13 +1,20 @@
 'use strict';
 
+const sanitise = text => text.replace(/[^\w ]/g, '');
+
 module.exports = function trimmedLinks($) {
 	$('a').each((i, el) => {
 		const $el = $(el);
 		const isRelatedBox = !!$el.parents('[data-trackable="related-box"]').length;
-		const text = $el.text();
+
+		// Ensure text doesn't contain HTML chars
+		const text = sanitise($el.text());
+
+		// Ensure URLs don't break out of data attribute
+		const href = $el.attr('href').replace('"', '%22');
 
 		if(!$el.attr('data-vars-link-destination')) {
-			$el.attr('data-vars-link-destination', $el.attr('href'));
+			$el.attr('data-vars-link-destination', href);
 		}
 
 		if(!$el.attr('data-vars-link-type')) {

--- a/server/lib/transforms/remove-invalid-links.js
+++ b/server/lib/transforms/remove-invalid-links.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const url = require('url');
+const reportError = require('../report-error');
+
+const validProtocols = [
+	'ftp', 'http', 'https', 'mailto', 'fb-messenger', 'skype',
+	'sms', 'tel', 'threema', 'viber', 'whatsapp',
+];
+
+// See https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii
+const validate = $el => {
+	const href = $el.attr('href');
+
+	// AMP links must have an href
+	if(!href) {
+		throw Error('Link with empty href');
+	}
+
+	const parsed = url.parse(href);
+	const protocol = (parsed.protocol || '').replace(/:$/, '');
+
+	// Require a valid protocol
+	if(validProtocols.indexOf(protocol) === -1) {
+		throw Error('Invalid link protocol');
+	}
+};
+
+module.exports = ($, options) => {
+	$('a').each((i, el) => {
+		const $el = $(el);
+
+		try{
+			validate($el);
+		} catch(e) {
+			reportError(options.raven, e, {extra: {
+				linkHtml: $.html($el),
+			}});
+			$el.replaceWith($el.contents());
+		}
+	});
+
+	return $;
+};


### PR DESCRIPTION
1. Sanitise text values, so that `<a ... data-vars-link-text="one device for " convenience""="">one device for "convenience"</a>` becomes `<a ... data-vars-link-text="one device for convenience">one device for "convenience"</a>`
2. Remove links with empty `href` or an invalid protocol (as per https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)