### PR TITLE
Change request AT-631

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ urls-*
 log-*
 .DS_Store
 scripts/*.xml
+cr-description.txt

--- a/makefile
+++ b/makefile
@@ -50,20 +50,22 @@ test: lint
 promote: change-request deploy-vcl-prod merge-fixversions
 	heroku pipelines:promote -a ft-google-amp-staging --to ft-google-amp-prod-eu,ft-google-amp-prod-us
 
-change-request:
+cr-description.txt:
+	heroku pipelines:diff -a ft-google-amp-staging > $@
+
+change-request: cr-description.txt
 	$(if $(KONSTRUCTOR_CR_KEY),,$(eval $(error KONSTRUCTOR_CR_KEY is required, check your .env)))
 
 	$(eval VERSION=$(shell scripts/version.sh))
-	$(eval CHANGELOG=$(shell heroku pipelines:diff -a ft-google-amp-staging))
 
-	echo change-request \
+	change-request \
 		--api-key $(KONSTRUCTOR_CR_KEY) \
 		--summary "Release google-amp $(VERSION)" \
-		--description "$(CHANGELOG)" \
+		--description-file $< \
 		--owner-email "ftmobile@ft.com" \
 		--service "google-amp" \
 		--environment "Production" \
-		--notify-channel "ft-tech-incidents" \
+		--notify-channel "ft-tech-incidents"
 
 merge-fixversions:
 	jira-merge-unreleased-versions

--- a/makefile
+++ b/makefile
@@ -47,8 +47,23 @@ test: lint
 	./scripts/test.sh
 
 # heroku and fastly
-promote: deploy-vcl-prod merge-fixversions
+promote: change-request deploy-vcl-prod merge-fixversions
 	heroku pipelines:promote -a ft-google-amp-staging --to ft-google-amp-prod-eu,ft-google-amp-prod-us
+
+change-request:
+	$(if $(KONSTRUCTOR_CR_KEY),,$(eval $(error KONSTRUCTOR_CR_KEY is required, check your .env)))
+
+	$(eval VERSION=$(shell scripts/version.sh))
+	$(eval CHANGELOG=$(shell heroku pipelines:diff -a ft-google-amp-staging))
+
+	echo change-request \
+		--api-key $(KONSTRUCTOR_CR_KEY) \
+		--summary "Release google-amp $(VERSION)" \
+		--description "$(CHANGELOG)" \
+		--owner-email "ftmobile@ft.com" \
+		--service "google-amp" \
+		--environment "Production" \
+		--notify-channel "ft-tech-incidents" \
 
 merge-fixversions:
 	jira-merge-unreleased-versions

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   ],
   "author": "richard.still@ft.com",
   "dependencies": {
-    "@financial-times/change-request": "^1.0.0",
     "@financial-times/fastly-tools": "^1.4.1",
     "@georgecrawford/postcss-remove-important": "^1.4.0",
     "@quarterto/assert-env": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@quarterto/heroku-memory-limit": "^1.2.0",
     "@quarterto/heroku-version-infer": "^3.2.3",
     "@quarterto/instrument-fetch": "^1.1.0",
+    "@quarterto/jira-get-release-issues": "^1.0.0",
     "@quarterto/package-version-github-release": "^1.0.0",
     "@quarterto/package-version-sentry-release": "^1.1.0",
     "@quarterto/post-sass": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "node": "^6.0.0"
   },
   "devDependencies": {
+    "@financial-times/change-request": "^1.1.0",
     "@quarterto/emphasize-monokai-sheet": "^1.3.0",
     "@quarterto/gaussian": "^1.0.0",
     "@quarterto/gaussian-percentile": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "author": "richard.still@ft.com",
   "dependencies": {
+    "@financial-times/change-request": "^1.0.0",
     "@financial-times/fastly-tools": "^1.4.1",
     "@georgecrawford/postcss-remove-important": "^1.4.0",
     "@quarterto/assert-env": "^1.3.0",

--- a/scripts/jira-release-issues.js
+++ b/scripts/jira-release-issues.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const jiraGetReleaseIssues = require('@quarterto/jira-get-release-issues');
+
+jiraGetReleaseIssues(process.argv[2], {
+	hostname: process.env.JIRA_HOST,
+	project: process.env.JIRA_PROJECT,
+	user: process.env.JIRA_USERNAME,
+	pass: process.env.JIRA_PASSWORD,
+})
+.then(r => r.json())
+.then(({issues}) =>
+	issues.length ?
+		issues.map(({key}) => `https://${process.env.JIRA_HOST}/browse/${key}`).join('\n') :
+		'None'
+).then(
+	console.log,
+	e => {
+		console.error(e.stack);
+		process.exit(1);
+	}
+);

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,7 +3,7 @@
 # same algorithm as https://github.com/quarterto/heroku-version-infer/blob/master/src/index.js,
 # just done locally with the current repository
 
-SHA=$(git rev-list --max-count=1 HEAD)
+SHA=$(git rev-list --merges --max-count=1 HEAD)
 MERGES=$(git rev-list $SHA --merges --first-parent | wc -l | xargs expr 1 +)
 
 echo "$MERGES.0.0-heroku-${SHA:0:7}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# same algorithm as https://github.com/quarterto/heroku-version-infer/blob/master/src/index.js,
+# just done locally with the current repository
+
+SHA=$(git rev-list --max-count=1 HEAD)
+MERGES=$(git rev-list $SHA --merges --first-parent | wc -l | xargs expr 1 +)
+
+echo "$MERGES.0.0-heroku-${SHA:0:7}"


### PR DESCRIPTION
@timdavenportFT this sets the CR summary to `Release google-amp XXX.0.0-heroku-abcdef1` and the description to the output of `heroku pipelines:diff`, which looks like:

```
=== ft-google-amp-staging is ahead of ft-google-amp-prod-us by 5 commits
SHA      Date                  Author        Message
───────  ────────────────────  ────────────  ───────────────────────────────────────────────────
36b8781  2016-11-07T16:31:20Z  Matt Brennan  Merge pull request #191 from Financial-Times/readme
1ec583d  2016-11-07T16:30:39Z  Matt Brennan  Merge pull request #164 from Financial-Times/robots
7b84a64  2016-11-07T16:25:13Z  Matt Brennan  Add rollback section
683816a  2016-09-21T16:03:24Z  Matt Brennan  disallow non-article paths in crawler
7e43e11  2016-11-01T17:26:02Z  Matt Brennan  deployment section in readme

https://github.com/Financial-Times/google-amp/compare/f3e0e1071aa5e24fd9a431d640cbc86ea8e8559d...36b87812a1f5efc359cf2b18cd675d21540fc3e8

=== ft-google-amp-staging is ahead of ft-google-amp-prod-eu by 5 commits
SHA      Date                  Author        Message
───────  ────────────────────  ────────────  ───────────────────────────────────────────────────
36b8781  2016-11-07T16:31:20Z  Matt Brennan  Merge pull request #191 from Financial-Times/readme
1ec583d  2016-11-07T16:30:39Z  Matt Brennan  Merge pull request #164 from Financial-Times/robots
7b84a64  2016-11-07T16:25:13Z  Matt Brennan  Add rollback section
683816a  2016-09-21T16:03:24Z  Matt Brennan  disallow non-article paths in crawler
7e43e11  2016-11-01T17:26:02Z  Matt Brennan  deployment section in readme

https://github.com/Financial-Times/google-amp/compare/9ac6cf6acfe23e729c16e6116f6ce2038fb3a8a4...36b87812a1f5efc359cf2b18cd675d21540fc3e8
```

Is that adequate?