### PR TITLE
Implement Krux fix

### DIFF
--- a/views/ads-iframe.html
+++ b/views/ads-iframe.html
@@ -52,6 +52,7 @@
 					var kruxFn = Krux.amp.withConfid('KHUSeE3x')
 					.withUserParam("kuid")
 					.withSegmentsParam("ksg")
+					.loadUserData()
 					.interchange().draw3p();
 
 					kruxFn(config, done);


### PR DESCRIPTION
@andrewgeorgiou1981 @andygnewman @quarterto 
Add the undocumented magic line that makes Krux work (along with their fixed remote.min.js). ¯\_(ツ)_/¯

Tested locally and it was making the userdata call, and on subsequent requests sent the kuid and ksegs to the ad call.