### PR TITLE
When calling Ammit, send the allocation id in the querystring

### DIFF
--- a/server/lib/ammit.js
+++ b/server/lib/ammit.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fetch = require('./fetch/wrap')(require('node-fetch'));
+const querystring = require('querystring');
 
 const {BadServerResponseError} = require('fetchres');
 
@@ -9,12 +10,15 @@ module.exports = ({allocationId, sessionId, countryCodeTwoLetters, continentCode
 		return Promise.resolve({});
 	}
 
-	return fetch('https://ammit-api.ft.com/uk', {
+	const qs = {
+		'allocation-id': allocationId
+	};
+	const ammitUrl = `https://ammit-api.ft.com/uk?${querystring.stringify(qs)}`;
+	return fetch(ammitUrl, {
 		method: 'HEAD',
 		headers: {
 			'api-key': process.env.AMMIT_APIKEY,
 			'ft-session-token': sessionId,
-			'ft-allocation-id': allocationId,
 			'ft-ammit-country': countryCodeTwoLetters,
 			'ft-ammit-continent-code': continentCode,
 			referer,


### PR DESCRIPTION
When calling Ammit, because Fastly has a vary limit for headers, we can't make use of CDN caching very efficiently. https://community.fastly.com/t/common-pitfalls-of-the-vary-header/370

In order to get better cache hit ratios, we move the allocation-id parameter from request header to the querystring.