### PR TITLE
HTTPS Only

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,10 @@ const fs = require('fs');
 const app = require('./server');
 
 const isDevelopment = app.get('env') === 'development';
+const hasCertificate = fs.existsSync(path.resolve(__dirname, 'key.pem'))
+	&& fs.existsSync(path.resolve(__dirname, 'cert.pem'));
 
-if(isDevelopment) {
+if(isDevelopment && hasCertificate) {
 	httpolyglot.createServer({
 		key: fs.readFileSync(path.resolve(__dirname, 'key.pem')),
 		cert: fs.readFileSync(path.resolve(__dirname, 'cert.pem')),

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ Prerequisites
    - To generate one, after running `npm install` you can login to Heroku with `heroku login --sso` and then make the file by running `npm run heroku-config` (note: for this command to work you will need to have access to the Heroku pipeline for this app)
    - If you add another environment variable, make sure to add it to `app.json`
 3. A self-signed certificate
-	 - To generate one, run `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN=localhost'`
+	 - Generate one with `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 1461 -nodes -config scripts/dev-utils/certificate.cnf`
+	 - Trust the certificate with `security import cert.pem; security add-trusted-cert cert.pem`
 
 Running
 ---
@@ -21,7 +22,7 @@ Running
 ```
 npm install
 npm start
-open http://localhost:5050/content/<FT article uuid>
+open https://local.ft.com:5050/content/<FT article uuid>
 ```
 
 Tests

--- a/scripts/dev-utils/certificate.cnf
+++ b/scripts/dev-utils/certificate.cnf
@@ -1,0 +1,15 @@
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+  [req_distinguished_name]
+O = The Financial Times Ltd.
+CN = local.ft.com
+  [v3_req]
+keyUsage = critical, digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+  [alt_names]
+DNS.1 = localhost
+DNS.2 = *.ft.com
+IP.1 = 127.0.0.1

--- a/server/index.js
+++ b/server/index.js
@@ -88,6 +88,17 @@ if(isProduction) {
 
 handlebars.express(app);
 
+app.set('x-powered-by', false);
+
+// Redirect http requests to https.
+app.get('*', (req, res, next) => {
+	if (req.secure) {
+		return next();
+	}
+
+	res.redirect(301, 'https://' + req.hostname + req.url);
+});
+
 // Add header for HSTS policy.
 app.use((req, res, next) => {
 	if (req.secure) {

--- a/server/index.js
+++ b/server/index.js
@@ -88,7 +88,11 @@ if(isProduction) {
 
 handlebars.express(app);
 
-app.set('x-powered-by', false);
+// Trust headers such as x-forwarded-for-proto from Heroku and Fastly.
+app.enable('trust proxy');
+
+// Remove the x-powered-by response header.
+app.disable('x-powered-by');
 
 // Redirect http requests to https.
 app.get('*', (req, res, next) => {

--- a/server/index.js
+++ b/server/index.js
@@ -88,6 +88,15 @@ if(isProduction) {
 
 handlebars.express(app);
 
+// Add header for HSTS policy.
+app.use((req, res, next) => {
+	if (req.secure) {
+		res.set('strict-transport-security', 'max-age=63072000; includeSubDomains; preload');
+	}
+
+	next();
+});
+
 // before logger to avoid logging robots.txt requests
 app.get('/robots.txt', (req, res) => {
 	res.send(`user-agent: *


### PR DESCRIPTION
Adds a redirect from http to https, and the `strict-transport-security` header.

This follows the HSTS policy we have on `www.ft.com`. I will follow this up by asking for `amp.ft.com`  to be added to the browser preload lists.