### PR TITLE
Notify next-webhooks on builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,3 +41,7 @@ jobs:
 
       - store_test_results:
           path: test-results
+
+notify:
+  webhooks:
+    - url: https://ft-next-webhooks.herokuapp.com/circleci2-workflow


### PR DESCRIPTION
Add this project to next-webhooks.

Sound legit? Seem like a good idea?

My thoughts are it should help us generalise our tooling.

This will mean amp gets:

* Releases in #ft-next-releases
* Master branch failure notifications in a Slack direct message