### PR TITLE
Revert "Update Renovate"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,12 @@
 {
   "extends": [
     "config:base",
+    ":preserveSemverRanges",
     "group:postcss",
     "group:linters"
   ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 1,
   "masterIssue": true,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,6 @@
     "group:postcss",
     "group:linters"
   ],
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 1,
   "masterIssue": true,
   "packageRules": [
     {


### PR DESCRIPTION
Reverts Financial-Times/google-amp#368.

After https://github.com/Financial-Times/google-amp/pull/369 was raised, I think it's wise for us to stick with preserving semver ranges on this project.