### PR TITLE
Fix broken page when href not provided on a element

### DIFF
--- a/server/lib/transforms/html/link-analytics.js
+++ b/server/lib/transforms/html/link-analytics.js
@@ -15,10 +15,12 @@ module.exports = match({
 		const text = sanitise(el.text());
 
 		// Ensure URLs don't break out of data attribute
-		const href = el.attr('href').replace('"', '%22');
+		if(el.attr('href')) {
+			const href = el.attr('href').replace('"', '%22');
 
-		if(!el.attr('data-vars-link-destination')) {
-			el.attr('data-vars-link-destination', href);
+			if(!el.attr('data-vars-link-destination')) {
+				el.attr('data-vars-link-destination', href);
+			}
 		}
 
 		if(!el.attr('data-vars-link-type')) {

--- a/test/utils/test-uuids.js
+++ b/test/utils/test-uuids.js
@@ -75,6 +75,7 @@ module.exports = [
 
 	// Reported as 5xx in Google Search Console
 	'514abee5-c09b-34f6-9a3a-865a64540a65',
+	'b0de8ce3-0822-3b6e-b8f1-b2c97bc92c88',
 	// '21b5893e-ba3a-32dc-bf31-271449002cc0', // Live-blog, this is just bad content, I think.
 	// 'f50909a8-95dd-3688-9b12-a67e1198e6d5', // Again a live-blog, bad content.
 


### PR DESCRIPTION
The ops-cops ticket I'm working on:
https://trello.com/c/HTF2gdDM/569-amp-alphaville-issue

Google Search Consol started reporting 500 errors returning from our AMP app.
This fix only addresses alphaville related issues when href is not provided on an `<a>` element.