### PR TITLE
Add table transformer

### DIFF
--- a/server/lib/transforms/body.js
+++ b/server/lib/transforms/body.js
@@ -27,6 +27,7 @@ const figure = require('./html/figure');
 const removeImageData = require('./html/remove-image-data');
 const imagePlaceholder = require('./html/image-placeholder');
 const subhead = require('./html/subhead');
+const table = require('./html/table');
 
 // runs transforms in parallel, keeping transforms that depend on each other in order.
 // `deps('foo')(bar)` tells `parallel` to run `foo` before `bar`.
@@ -50,6 +51,7 @@ const transformBody = cheerioTransform(parallel({
 	infoBox,
 	contentLinks,
 	subhead,
+	table,
 }));
 
 module.exports = (body, options = {}) => Promise.resolve(body)

--- a/server/lib/transforms/html/table.js
+++ b/server/lib/transforms/html/table.js
@@ -2,17 +2,16 @@
 
 const match = require('@quarterto/cheerio-match-multiple');
 
-function generateTableHref(el) {
+function generateTableHref(el, uuid) {
 	const tableId = el.attr('id');
-	const contentId = tableId.match(/table-(.*)_\d/)[1];
 
-	return `https://ft.com/content/${contentId}#${tableId}`;
+	return `https://ft.com/content/${uuid}#${tableId}`;
 }
 
 module.exports = match({
-	'table'(el) {
-		const href = generateTableHref(el);
+	'table'(el, a, b, {uuid}) {
+		const href = generateTableHref(el, uuid);
 
-		el.closest('.o-table-container').replaceWith(`<a href="${href}">Go to table</a>`);
+		el.closest('.o-table-container').replaceWith(`<a href="${href}">View the table</a>`);
 	},
 });

--- a/server/lib/transforms/html/table.js
+++ b/server/lib/transforms/html/table.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const match = require('@quarterto/cheerio-match-multiple');
+
+function generateTableHref(el) {
+	const tableId = el.attr('id');
+	const contentId = tableId.match(/table-(.*)_\d/)[1];
+
+	return `https://ft.com/content/${contentId}#${tableId}`;
+}
+
+module.exports = match({
+	'table'(el) {
+		const href = generateTableHref(el);
+
+		el.closest('.o-table-container').replaceWith(`<a href="${href}">Go to table</a>`);
+	},
+});

--- a/test/amp-transform/table.js
+++ b/test/amp-transform/table.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const {expect} = require('../utils/chai');
+const transformBody = require('../../server/lib/transforms/body');
+
+describe('table transform', () => {
+	it('should replace table with link', async () => {
+		const tableId = 'table-00000000-000-0000-0000-000000000000_2';
+		const tableHtml = `
+			<div class="o-table-container o-table-container--contracted">
+				<div class="o-table-overlay-wrapper">
+					<div class="o-table-scroll-wrapper">
+						<table id="${tableId}"></table>
+					</div>
+				</div>
+			</div>
+		`;
+		expect(
+			await transformBody(tableHtml)
+		).dom.to.equal(
+			`<a href="https://ft.com/content/00000000-000-0000-0000-000000000000#${tableId}">Go to table</a>`
+		);
+	});
+});

--- a/test/amp-transform/table.js
+++ b/test/amp-transform/table.js
@@ -16,9 +16,9 @@ describe('table transform', () => {
 			</div>
 		`;
 		expect(
-			await transformBody(tableHtml)
+			await transformBody(tableHtml, {uuid: '00000000-000-0000-0000-000000000000'})
 		).dom.to.equal(
-			`<a href="https://ft.com/content/00000000-000-0000-0000-000000000000#${tableId}">Go to table</a>`
+			`<a href="https://ft.com/content/00000000-000-0000-0000-000000000000#${tableId}">View the table</a>`
 		);
 	});
 });


### PR DESCRIPTION
This will convert the table into a link that goes to the article page.
The flat o-table style not behaving as it expected so
we will use this solution for the moment.


<img width="517" alt="screenshot 2019-02-15 at 13 27 26" src="https://user-images.githubusercontent.com/2817762/52859764-7c45a200-3125-11e9-81aa-49c1c8217e1b.png">
