### PR TITLE
Update package author email and service contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Google",
     "AMP-HTML"
   ],
-  "author": "matthew.brennan@ft.com",
+  "author": "bren.brightwell@ft.com",
   "dependencies": {
     "@financial-times/fastly-tools": "^1.7.1",
     "@financial-times/n-es-client": "^1.6.2",

--- a/server/index.js
+++ b/server/index.js
@@ -40,12 +40,12 @@ ftwebservice(app, {
 				email: 'richard.still@ft.com',
 			},
 			{
-				name: 'Matthew Brennan',
-				email: 'matthew.brennan@ft.com',
+				name: 'Bren Brightwell',
+				email: 'bren.brightwell@ft.com',
 			},
 			{
-				name: 'George Crawford',
-				email: 'george.crawford@ft.com',
+				name: 'Rowan Beentje',
+				email: 'rowan.beentje@ft.com',
 			},
 		],
 	},


### PR DESCRIPTION
Release log was erroring because Konstructor didn't know about that email address any more :)

I think it makes sense for you still be listed as author and a contact, although we'll try and take over more when more work needs to be done?