### PR TITLE
Force n-test smoke tests to use https

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,13 +38,3 @@ run:
 
 build-production:
 	node -r dotenv/config server/lib/article/css
-
-test-review-ap%:
-	$(MAKE) gtg-review-app
-	TEST_URL="https://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
-		$(MAKE) smoke a11y
-	# Destroy review app if it passes tests on the master branch
-ifeq ($(CIRCLE_BRANCH),master)
-	heroku destroy -a $$(cat $(REVIEW_APP_FILE)) --confirm $$(cat $(REVIEW_APP_FILE))
-endif
-	@$(DONE)

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -5,7 +5,7 @@ module.exports = [
 	{
 		timeout: 10000,
 		urls: {
-			'/__health': 200,
+			'/__health': {status: 200, https: true},
 		},
 	},
 
@@ -15,6 +15,7 @@ module.exports = [
 		urls: {
 			'/content/146da558-4dee-11e3-8fa5-00144feabdc0': {
 				status: 200,
+				https: true,
 				waitUntil: ['load', 'networkidle2'],
 				pageErrors: 2, // some URLs don't work on 3002 and so error
 				cacheHeaders: true,


### PR DESCRIPTION
n-gage has a bunch of smoke test behaviour that relies on http URLs in [review-app.mk](https://github.com/Financial-Times/n-gage/blob/v3.7.1/src/tasks/review-app.mk#L37) and [deploy.mk](https://github.com/Financial-Times/n-gage/blob/v3.7.1/src/tasks/deploy.mk#L75) .  Force https use to let these work with AMP staging URLs.

 🐿 v2.12.3