### PR TITLE
move fallbackEntitlement outside of service configuration

### DIFF
--- a/views/layouts/layout.html
+++ b/views/layouts/layout.html
@@ -61,11 +61,11 @@
 			"score": {
 				"supportsViewer": 0
 			},
-		  "fallbackEntitlement": {
+			"fallbackEntitlement": {
 				"source": "fallback",
 				"granted": true,
 				"grantReason": "METERING"
-		  }
+			}
 		}
 		</script>
 

--- a/views/layouts/layout.html
+++ b/views/layouts/layout.html
@@ -53,11 +53,6 @@
 						"login": "{{{AUTH_LOGIN_URL}}}readerId=READER_ID&location=RETURN_URL%23success=true",
 						"logout": "{{{AUTH_LOGOUT_URL}}}rid=READER_ID&location=RETURN_URL%23success=true",
 						"subscribe": "{{{pspURL}}}"
-					},
-					"fallbackEntitlement": {
-						"source": "fallback",
-						"granted": true,
-						"grantReason": "METERING"
 					}
 				},
 				{ "serviceId": "subscribe.google.com" }
@@ -65,7 +60,12 @@
 			"preferViewerSupport": true,
 			"score": {
 				"supportsViewer": 0
-			}
+			},
+		  "fallbackEntitlement": {
+				"source": "fallback",
+				"granted": true,
+				"grantReason": "METERING"
+		  }
 		}
 		</script>
 


### PR DESCRIPTION
it should be top-level according to https://amp.dev/documentation/components/amp-subscriptions/#service-configuration. this should fix the symptoms of https://trello.com/c/vmKO5Qj1/1184-amp-barrier-for-content-that-should-be-free but not the root cause errors.