### PR TITLE
feat: use next-elastic.glb.ft.com CNAME to connect to Elasticsearch

### DIFF
--- a/server/health/elastic-search.js
+++ b/server/health/elastic-search.js
@@ -8,12 +8,12 @@ module.exports = healthCheck({
 	name: 'Check TCP/IP connectivity to this app\'s configured Elastic Search hostname on port 443',
 	businessImpact: 'Newly crawled FT articles will not have AMP versions '
 		+ 'of content available in e.g. the Google news carousel',
-	technicalSummary: 'Attempts to connect to next-elastic.ft.com:443. All '
+	technicalSummary: 'Attempts to connect to next-elastic.glb.ft.com:443. All '
 		+ 'content is requested from this host; without connectivity, when ft.com '
 		+ 'is crawled, new content will not be available as AMP pages.',
 	panicGuide: 'Check connectivity by running '
-		+ `\`heroku run --app ${process.env.HEROKU_APP_NAME} nc -w 5 -z next-elastic.ft.com 443\`.`,
-}, () => tcpFetch('next-elastic.ft.com', 443)
+		+ `\`heroku run --app ${process.env.HEROKU_APP_NAME} nc -w 5 -z next-elastic.glb.ft.com 443\`.`,
+}, () => tcpFetch('next-elastic.glb.ft.com', 443)
 	.then(
 		ms => ({ok: true, checkOutput: ms}),
 		err => ({ok: false, checkOutput: err})


### PR DESCRIPTION
As part of the DNS migration from Dyn to Route53 the foundation services team are requesting us to move DNS records using Dyn's Traffic Management service under the glb.ft.com zone.

The next-elastic.glb.ft.com record is all setup to load balance DNS lookups, and resolves to the same records as next-elastic.ft.com.

Related change in n-es-client is https://github.com/Financial-Times/n-es-client/pull/41.