### PR TITLE
Fix check for env variable

### DIFF
--- a/server/lib/article/article-flags.js
+++ b/server/lib/article/article-flags.js
@@ -65,5 +65,5 @@ module.exports = (article, options) => Object.assign(article, {
 
 	visibilityOptIn: segmentArticle(article),
 
-	showSwGButton: process.env.SHOW_SWG_BUTTON,
+	showSwGButton: process.env.SHOW_SWG_BUTTON === 'true',
 });


### PR DESCRIPTION
We had a similar issue trying to disable the swg button on the barriers. Handlebars is basically checking `{{#if "false"}}` and since it's a string it's truthy.

🐿 v2.12.3