### PR TITLE
Redirect US 2019 delegate tracker to FT.com

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -15,7 +15,8 @@ module.exports = {
 			'146da558-4dee-11e3-8fa5-00144feabdc0', // server/controllers/redirect.js:4, test/smoke.js:16
 			'acee4131-99c2-09d3-a635-873e61754ec6', // server/lib/article/article-flags.js:10
 			'e8813dd4-d00d-11e5-831d-09f7778e7377', // server/lib/article/article-flags.js:54, test/utils/test-uuids.js:27
-			'263615ca-d873-11e9-8f9b-77216ebe1f17', // server/lib/article/assemble.js:65
+			'263615ca-d873-11e9-8f9b-77216ebe1f17', // server/controllers/amp-page.js:8
+			'f3bb0944-4437-11ea-abea-0c7a29cd66fe', // server/controllers/amp-page.js:9
 			'b4284269-2951-3169-ab98-88c184da5e88', // test/amp-transform/blockquotes.js:39, test/utils/test-uuids.js:32
 			'56f6ad50-da52-11e5-a72f-1e7744c66818', // test/amp-transform/external-image.js:7|25
 			'0a5e1620-c0f5-11e5-846f-79b0e3d20eaf', // test/amp-transform/related-box.js:38|44

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -5,7 +5,8 @@ const analytics = require('../lib/analytics');
 
 // HACK: redirect certain articles to ft.com
 const articlesToSkip = [
-	'263615ca-d873-11e9-8f9b-77216ebe1f17', // general election poll tracker: contains image that shouldn't be cached
+	'263615ca-d873-11e9-8f9b-77216ebe1f17', // UK 2019 general election poll tracker: contains dynamic image that shouldn't be cached
+	'f3bb0944-4437-11ea-abea-0c7a29cd66fe', // US 2019 democratic primaries delegate tracker: contains dynamic image that shouldn't be cached
 ];
 
 module.exports = (req, res, next) => {


### PR DESCRIPTION
US delegate tracker contains a dynamic image which should not be cached

Related to https://github.com/Financial-Times/next-article/pull/3662