### PR TITLE
Add logic to only show the SWG button on `isReadyToPay` 🐿 v2.12.5

### DIFF
--- a/server/lib/article/article-flags.js
+++ b/server/lib/article/article-flags.js
@@ -66,4 +66,5 @@ module.exports = (article, options) => Object.assign(article, {
 	visibilityOptIn: segmentArticle(article),
 
 	showSwGButton: process.env.SHOW_SWG_BUTTON === 'true',
+	enableSwGReadyToPay: process.env.ENABLE_SWG_READY_TO_PAY === 'true',
 });

--- a/views/partials/barrier.html
+++ b/views/partials/barrier.html
@@ -60,23 +60,27 @@
 </amp-list>
 
 {{#if showSwGButton}}
-<div class="amp-access-barrier__offer" subscriptions-actions subscriptions-display="factors['subscribe.google.com'].isReadyToPay AND NOT granted">
-	<h2 class="amp-access-barrier__offer-title">
-		Digital or Premium Digital
-	</h2>
-
-	<div class="amp-access-barrier__offer-description">
-		You can also subscribe to the FT Digital or Premium Digital with Google
-	</div>
-	<button 
-		class="amp-access-barrier__swg-button" 
-		subscriptions-action="subscribe" 
-		subscriptions-service="subscribe.google.com" 
-		subscriptions-display="true"
+	<div 
+		class="amp-access-barrier__offer" 
+		subscriptions-actions 
+		subscriptions-display="{{#if enableSwGReadyToPay}}factors['subscribe.google.com'].isReadyToPay AND {{/if}}NOT granted"
 	>
-		Subscribe with Google
-	</button>
-</div>
+		<h2 class="amp-access-barrier__offer-title">
+			Digital or Premium Digital
+		</h2>
+
+		<div class="amp-access-barrier__offer-description">
+			You can also subscribe to the FT Digital or Premium Digital with Google
+		</div>
+		<button 
+			class="amp-access-barrier__swg-button" 
+			subscriptions-action="subscribe" 
+			subscriptions-service="subscribe.google.com" 
+			subscriptions-display="true"
+		>
+			Subscribe with Google
+		</button>
+	</div>
 {{/if}}
 
 <div class="amp-access-barrier__footer">

--- a/views/partials/barrier.html
+++ b/views/partials/barrier.html
@@ -60,7 +60,7 @@
 </amp-list>
 
 {{#if showSwGButton}}
-<div class="amp-access-barrier__offer">
+<div class="amp-access-barrier__offer" subscriptions-actions subscriptions-display="factors['subscribe.google.com'].isReadyToPay AND NOT granted">
 	<h2 class="amp-access-barrier__offer-title">
 		Digital or Premium Digital
 	</h2>
@@ -68,7 +68,14 @@
 	<div class="amp-access-barrier__offer-description">
 		You can also subscribe to the FT Digital or Premium Digital with Google
 	</div>
-	<button class="amp-access-barrier__swg-button" subscriptions-action="subscribe" subscriptions-service="subscribe.google.com" subscriptions-display="NOT granted">Subscribe with Google</button>
+	<button 
+		class="amp-access-barrier__swg-button" 
+		subscriptions-action="subscribe" 
+		subscriptions-service="subscribe.google.com" 
+		subscriptions-display="true"
+	>
+		Subscribe with Google
+	</button>
 </div>
 {{/if}}
 


### PR DESCRIPTION
 - Conditionally show SWG buttons if `isReadyToPay` flag is `true`.

[Ticket](https://financialtimes.atlassian.net/browse/AC-49?atlOrigin=eyJpIjoiNTk3MTdlMGRjM2Q1NGNlM2I3ODg0MGJmODk3MTBkMDEiLCJwIjoiaiJ9)