### PR TITLE
Remove coronavirus economic tracker from AMP 🐿 v2.12.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -221,9 +221,9 @@
       }
     },
     "@financial-times/n-es-client": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-es-client/-/n-es-client-1.7.0.tgz",
-      "integrity": "sha512-JTuVdqM+2KoAsX5UfqfJU6X/MbOBdD02fAkWYmllMptXlwJ7qQLxP1HjkjYjGMMZXSj4Wik3W2AuWmYNIdotUQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-es-client/-/n-es-client-1.8.0.tgz",
+      "integrity": "sha512-Fy5y2TySAmTTbEX+aqZ/mIXn7ujwxiS59qxcR/bO9L6f6hIuhXXJ03VCLbRgZJf5Gvxk3dh2YRaokdJIH6G2zw==",
       "requires": {
         "@financial-times/n-logger": "^6.0.0",
         "http-errors": "^1.6.2",
@@ -231,9 +231,9 @@
       },
       "dependencies": {
         "@financial-times/n-logger": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.1.0.tgz",
-          "integrity": "sha512-doBJSBpUUYgTbASgSdQ1CzTIwCUEYrYCBo7FcKU70jsgCNwkYQizbEpb3gmyEL4I+7rCeRENrvrcWbQkT3yjeQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.1.1.tgz",
+          "integrity": "sha512-xjzRYjkvCHK4JFxF9FKxBEbvBzOjb2lhsQwxsJEdcvO7z72FEJOHCMln3AbqyzfgKtwGFN3veWRa61peASZk4w==",
           "requires": {
             "isomorphic-fetch": "^2.2.1",
             "json-stringify-safe": "^5.0.1",

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -4,9 +4,9 @@ module.exports = {
 	files: {
 		allow: [
 			'makefile',
-			'scripts/dev-utils/certificate.cnf'
+			'scripts/dev-utils/certificate.cnf',
 		],
-		allowOverrides: []
+		allowOverrides: [],
 	},
 	strings: {
 		deny: [],
@@ -18,6 +18,7 @@ module.exports = {
 			'263615ca-d873-11e9-8f9b-77216ebe1f17', // server/controllers/amp-page.js:8
 			'f3bb0944-4437-11ea-abea-0c7a29cd66fe', // server/controllers/amp-page.js:9
 			'a26fbf7e-48f8-11ea-aeb3-955839e06441', // server/controllers/amp-page.js:10
+			'0c13755a-6867-11ea-800d-da70cff6e4d3', // server/controllers/amp-page.js:11
 			'b4284269-2951-3169-ab98-88c184da5e88', // test/amp-transform/blockquotes.js:39, test/utils/test-uuids.js:32
 			'56f6ad50-da52-11e5-a72f-1e7744c66818', // test/amp-transform/external-image.js:7|25
 			'0a5e1620-c0f5-11e5-846f-79b0e3d20eaf', // test/amp-transform/related-box.js:38|44
@@ -118,6 +119,6 @@ module.exports = {
 			'21b5893e-ba3a-32dc-bf31-271449002cc0', // test/utils/test-uuids.js:79
 			'f50909a8-95dd-3688-9b12-a67e1198e6d5', // test/utils/test-uuids.js:80
 			'079a37bc-db50-11e7-a039-c64b1c09b482', // test/utils/test-uuids.js:83
-		]
-	}
+		],
+	},
 };

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -8,6 +8,7 @@ const articlesToSkip = [
 	'263615ca-d873-11e9-8f9b-77216ebe1f17', // UK 2019 general election poll tracker: contains dynamic image that shouldn't be cached
 	'f3bb0944-4437-11ea-abea-0c7a29cd66fe', // US 2019 democratic primaries delegate tracker: contains dynamic image that shouldn't be cached
 	'a26fbf7e-48f8-11ea-aeb3-955839e06441', // Coronavirus tracker map: contains dynamic image that shouldn't be cached
+	'0c13755a-6867-11ea-800d-da70cff6e4d3', // Coronavirus economic tracker page: contains dynamic image taht shouldn't be cached
 ];
 
 module.exports = (req, res, next) => {


### PR DESCRIPTION
Removes the coronavirus economic tracker page from AMP (it contains a dynamic image that should not go through AMP)

Related to https://github.com/Financial-Times/next-article/pull/3741