### PR TITLE
NOPS-COPS-36 Fix Transparent Images

### DIFF
--- a/scss/_hacks.scss
+++ b/scss/_hacks.scss
@@ -1,3 +1,9 @@
+/* Give all images a paper-coloured background to prevent PNGs from being
+displayed against black when open in a lightbox or undergoing transitions. */
+img {
+	background-color: oColorsGetPaletteColor('pink');
+}
+
 $o-buttons-themes__standout: map-merge($o-buttons-themes__standout, (
 	pressedselected: (
 		background: oColorsGetColorFor(o-buttons-standout-pressedselected, background)


### PR DESCRIPTION
There's a problem with images which contain transparency (PNGs, for example) when they're opened in light-boxes. Because light-boxes have a black background, they can make some images unreadable. It looks like this:

<img width="612" alt="Screenshot 2020-04-20 at 12 49 26" src="https://user-images.githubusercontent.com/43537633/79748568-953b7b80-8305-11ea-84b8-6355128df2af.png">

Whereas in actuality we'd like it to look like this:

<img width="612" alt="Screenshot 2020-04-20 at 12 50 04" src="https://user-images.githubusercontent.com/43537633/79748603-9f5d7a00-8305-11ea-846e-474f4bd69312.png">

Due to the unique way Amp transitions images into and out of light-boxes, it's not possible to just apply a background-color to `amp-lightbox-gallery img`. If you do, you get an ugly moment of black as the transition happens. It looks like this:

![ezgif-2-8474508cf7cf](https://user-images.githubusercontent.com/43537633/79748981-417d6200-8306-11ea-8689-e13deb2151d3.gif)

The solution is a hack which adds `background-color` to all images, regardless of whether they're in a light-box or undergoing transitions. Since there are no occasions where we don't display transparent images against a non-paper-coloured background, this shouldn't cause any damage.