### PR TITLE
Fix for express-handlebars unit tests

### DIFF
--- a/test/handlebars/express.test.js
+++ b/test/handlebars/express.test.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const request = require('supertest');
-const app = require('../utils/hbs-app/main');
+let app;
 
 describe('express handlebars setup', function () {
 	before(function () {
+		app = require('../utils/hbs-app/main');
 		return app.promise;
 	});
 
@@ -39,6 +40,4 @@ describe('express handlebars setup', function () {
 				.expect(200, /Concat onetwothree/);
 		});
 	});
-
-
 });


### PR DESCRIPTION
Running `make test` would initialize the express app in `/utils/hbs-app/main'.js` before running all other tests and by the time it got to the handlebars tests it would start giving 500 errors

As a fix, I moved the initialization of the express app in `/utils/hbs-app/main'.js` to be right before the handlebars unit tests run.