### PR TITLE
ACQ-502 Fix issue with pricing and needless text

### DIFF
--- a/scss/barrier.scss
+++ b/scss/barrier.scss
@@ -128,12 +128,6 @@ $barrier-padding: 20px;
 	@include oTypographySans(s);
 }
 
-.amp-access-barrier__offer-description-title {
-	@include oTypographySansBold(s);
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
 .amp-access-barrier__offer-description-items {
 	list-style: none;
 	margin: 0 0 1em;

--- a/server/lib/format-barrier-data.js
+++ b/server/lib/format-barrier-data.js
@@ -12,8 +12,8 @@ module.exports.formatBarrierData = offer => {
 		formatted.secondaryPricing = copyTemplate.replace(PRICE_MATCH, secondaryPriceValue);
 	}
 
-	if (offer.pricingCopyPricePath && offer.pricingCopyTemplate) {
-		const pricingValue = get(offer, offer.pricingCopyPricePath);
+	const pricingValue = get(offer, offer.pricingCopyPricePath);
+	if (pricingValue && offer.pricingCopyTemplate) {
 		formatted.pricingCopy = offer.pricingCopyTemplate.replace(PRICE_MATCH, pricingValue);
 	} else {
 		formatted.pricingCopy = offer.pricingCopy;

--- a/server/lib/format-barrier-data.js
+++ b/server/lib/format-barrier-data.js
@@ -19,8 +19,8 @@ module.exports.formatBarrierData = offer => {
 		formatted.pricingCopy = offer.pricingCopy;
 	}
 
-	if (offer.promoPricingCopyTemplate && offer.promoPricingCopyPricePath) {
-		const promoPricingValue = get(offer, offer.promoPricingCopyPricePath);
+	const promoPricingValue = get(offer, offer.promoPricingCopyPricePath);
+	if (promoPricingValue && offer.promoPricingCopyTemplate) {
 		formatted.promoPricingCopy = offer.promoPricingCopyTemplate.replace(PRICE_MATCH, promoPricingValue);
 	}
 

--- a/test/lib/format-barrier-data.spec.js
+++ b/test/lib/format-barrier-data.spec.js
@@ -81,7 +81,7 @@ describe('formatBarrierData(offer)', () => {
 		expect(formatted.pricingCopy).to.equal(mockedItem.pricingCopy);
 	});
 
-	it('ishould return normal price if the priceValue pricingCopyPricePath is missing', () => {
+	it('should return normal price if the pricingCopyPricePath is missing or invalid', () => {
 		mockedItem.pricingCopyPricePath = 'missing.pricing.value';
 		formatted = formatBarrierData(mockedItem);
 		expect(formatted.pricingCopy).to.equal(mockedItem.pricingCopy);

--- a/test/lib/format-barrier-data.spec.js
+++ b/test/lib/format-barrier-data.spec.js
@@ -78,7 +78,12 @@ describe('formatBarrierData(offer)', () => {
 		delete mockedItem.pricingCopyTemplate;
 
 		formatted = formatBarrierData(mockedItem);
+		expect(formatted.pricingCopy).to.equal(mockedItem.pricingCopy);
+	});
 
-		expect(formatted.pricingCopy).to.equal(undefined);
+	it('ishould return normal price if the priceValue pricingCopyPricePath is missing', () => {
+		mockedItem.pricingCopyPricePath = 'missing.pricing.value';
+		formatted = formatBarrierData(mockedItem);
+		expect(formatted.pricingCopy).to.equal(mockedItem.pricingCopy);
 	});
 });

--- a/test/lib/format-barrier-data.spec.js
+++ b/test/lib/format-barrier-data.spec.js
@@ -65,15 +65,19 @@ describe('formatBarrierData(offer)', () => {
 		});
 	});
 
-	it('should return correct formatted secondary pricing', () => {
+	it('should return correctly formatted secondaryPricing', () => {
 		expect(formatted.secondaryPricing).to.equal('Test price 6 per month');
 	});
 
-	it('should return correct formatted pricingCopy from template', () => {
+	it('should return correctly formatted pricingCopy', () => {
 		expect(formatted.pricingCopy).to.equal('Test trial 2 price monthly');
 	});
 
-	it('should return correct formatted pricingCopy', () => {
+	it('should return correctly formatted promoPricingCopy', () => {
+		expect(formatted.promoPricingCopy).to.equal('Test promo 150 price per year');
+	});
+
+	it('should return correctly formatted pricingCopy', () => {
 		delete mockedItem.pricingCopyPricePath;
 		delete mockedItem.pricingCopyTemplate;
 
@@ -85,5 +89,19 @@ describe('formatBarrierData(offer)', () => {
 		mockedItem.pricingCopyPricePath = 'missing.pricing.value';
 		formatted = formatBarrierData(mockedItem);
 		expect(formatted.pricingCopy).to.equal(mockedItem.pricingCopy);
+	});
+
+	it('should return correctly formatted promoPricingCopy', () => {
+		delete mockedItem.promoPricingCopyPricePath;
+		delete mockedItem.promoPricingCopyTemplate;
+
+		formatted = formatBarrierData(mockedItem);
+		expect(formatted.hasOwnProperty('promoPricingCopy')).to.equal(false);
+	});
+
+	it('should return correctly formatted promoPricingCopy', () => {
+		mockedItem.promoPricingCopyPricePath = 'invalid.promo.price';
+		formatted = formatBarrierData(mockedItem);
+		expect(formatted.hasOwnProperty('promoPricingCopy')).to.equal(false);
 	});
 });

--- a/views/partials/barrier.html
+++ b/views/partials/barrier.html
@@ -29,9 +29,6 @@
 			</h2>
 
 			<div class="amp-access-barrier__offer-description">
-				\{{#description.title}}
-				<h3 class="amp-access-barrier__offer-description-title">\{{description.title}}</h3>
-				\{{/description.title}}
 				\{{#basicDescription}}
 					<p>\{{{basicDescription}}}</p>
 				\{{/basicDescription}}


### PR DESCRIPTION
# Story
https://financialtimes.atlassian.net/browse/ACQ-502

# Description
Fixes issues appearing resulting in bad PriceCopy being produced, as well as additional text being rendered needlessly.

# Changes in this PR
* Make sure that when producing a templated value, the produced string is correct
* Remove `description.title` from barrier template