### PR TITLE
ACQ-502 Restore original linking - working offer

### DIFF
--- a/views/partials/barrier.html
+++ b/views/partials/barrier.html
@@ -70,12 +70,11 @@
 				</p>
 			\{{/formatted.promoPricingCopy}}
 
-			\{{#alternateSelectText}}
-				<a href="{{#href}}{{href}}{{/href}}{{^href}}https://www.ft.com/signup?offerId={{id}}{{/href}}" type="barrier-subscribe" class="amp-access-barrier__button">\{{alternateSelectText}}</a>
-			\{{/alternateSelectText}}
-			\{{^alternateSelectText}}
-				<a href="{{#href}}{{href}}{{/href}}{{^href}}https://www.ft.com/signup?offerId={{id}}{{/href}}" type="barrier-subscribe" class="amp-access-barrier__button">Select</a>
-			\{{/alternateSelectText}}
+			{{> link
+				href='{{#href}}{{href}}{{/href}}{{^href}}https://www.ft.com/signup?offerId={{id}}{{/href}}'
+				text='{{#alternateSelectText}}{{alternateSelectText}}{{/alternateSelectText}}{{^alternateSelectText}}Select{{/alternateSelectText}}'
+				type='barrier-subscribe'
+				class='amp-access-barrier__button'}}
 		</div>
 	</template>
 </amp-list>


### PR DESCRIPTION
# Story
https://financialtimes.atlassian.net/browse/ACQ-502

# This PR
* Fixes linking issue in offer CTA - links were broken and not loading offers correctly
* Reverts changes from https://github.com/Financial-Times/google-amp/pull/450/files#diff-cd5c16eab1afbbb91e2fa0f59788b69fL59 with slightly updated behaviour, where alternative select text is used

# Screenshots
n/a