### PR TITLE
Remove CircleCI todo from config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,6 @@ jobs:
       - run:
           name: shared-helper / setup-heroku-cli
           command: .circleci/shared-helpers/helper-setup-heroku-cli
-          # TODO: Move this out into next circleci app preset env variables in Vault
-          environment:
-            HEROKU_LOGIN: next.developers@ft.com
       - run:
           name: Create and test Heroku review app
           command: make test-review-app
@@ -122,9 +119,6 @@ jobs:
       - run:
           name: shared-helper / helper-setup-heroku-cli
           command: .circleci/shared-helpers/helper-setup-heroku-cli
-          # TODO: Move this out into next circleci app preset env variables in Vault
-          environment:
-            HEROKU_LOGIN: next.developers@ft.com
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps


### PR DESCRIPTION
We've now added this to the shared Next folder in Vault so we can remove this todo :tada: