### PR TITLE
Upgrade n-es-client ^1.8.0 -> 3.0.0 (Elasticsearch v7 cluster)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "bren.brightwell@ft.com",
   "dependencies": {
     "@financial-times/fastly-tools": "^1.7.1",
-    "@financial-times/n-es-client": "^1.8.0",
+    "@financial-times/n-es-client": "Financial-Times/n-es-client#make-requests-to-next-elasticsearch-v7-gslb-ft-com",
     "@georgecrawford/postcss-remove-important": "^1.4.0",
     "@quarterto/assert-env": "^1.4.0",
     "@quarterto/assert-heroku-env": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "bren.brightwell@ft.com",
   "dependencies": {
     "@financial-times/fastly-tools": "^1.7.1",
-    "@financial-times/n-es-client": "Financial-Times/n-es-client#make-requests-to-next-elasticsearch-v7-gslb-ft-com",
+    "@financial-times/n-es-client": "3.0.0",
     "@georgecrawford/postcss-remove-important": "^1.4.0",
     "@quarterto/assert-env": "^1.4.0",
     "@quarterto/assert-heroku-env": "^1.3.0",


### PR DESCRIPTION
This PR changes the version of `n-es-client` to GitHub branch [`make-requests-to-next-elasticsearch-v7-gslb-ft-com`](https://github.com/Financial-Times/n-es-client/tree/make-requests-to-next-elasticsearch-v7-gslb-ft-com) so that all of its Elasticsearch requests are directed to the new Elasticsearch v7 cluster.

Once all apps that make Elasticsearch requests via `n-es-client` have been verified as working then a new major version of that package will be released and this PR updated to instead use that.

**Update:** `n-es-client` v3.0.0, which sends requests to the new Elasticsearch v7 cluster, has been released and this PR has been updated to consume that release.