### PR TITLE
Switch healthcheck to Elasticsearch v7 cluster

### DIFF
--- a/server/health/elastic-search.js
+++ b/server/health/elastic-search.js
@@ -8,12 +8,12 @@ module.exports = healthCheck({
 	name: 'Check TCP/IP connectivity to this app\'s configured Elastic Search hostname on port 443',
 	businessImpact: 'Newly crawled FT articles will not have AMP versions '
 		+ 'of content available in e.g. the Google news carousel',
-	technicalSummary: 'Attempts to connect to next-elasticsearch.nlb.ft.com:443. All '
+	technicalSummary: 'Attempts to connect to next-elasticsearch-v7.gslb.ft.com:443. All '
 		+ 'content is requested from this host; without connectivity, when ft.com '
 		+ 'is crawled, new content will not be available as AMP pages.',
 	panicGuide: 'Check connectivity by running '
-		+ `\`heroku run --app ${process.env.HEROKU_APP_NAME} nc -w 5 -z next-elasticsearch.nlb.ft.com 443\`.`,
-}, () => tcpFetch('next-elasticsearch.nlb.ft.com', 443)
+		+ `\`heroku run --app ${process.env.HEROKU_APP_NAME} nc -w 5 -z next-elasticsearch-v7.gslb.ft.com 443\`.`,
+}, () => tcpFetch('next-elasticsearch-v7.gslb.ft.com', 443)
 	.then(
 		ms => ({ok: true, checkOutput: ms}),
 		err => ({ok: false, checkOutput: err})


### PR DESCRIPTION
Part of the Elasticsearch migration.

This PR switches the healthcheck so instead of pointing at the soon-to-be retired v5 cluster it instead points to the now active v7 cluster.