### PR TITLE
NOPS-48 remove link to FastFT since it's now defunct.

### DIFF
--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -35,9 +35,6 @@
 				<a class="o-header__nav-link o-header__nav-link--primary" href="https://www.ft.com" data-vars-link-destination="https://www.ft.com" data-vars-link-type="nav-ftcom" data-vars-link-text="Visit FT.com">Visit FT.com</a>
 			</li>
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="https://www.ft.com/fastft" data-vars-link-destination="https://www.ft.com/fastft" data-vars-link-type="nav-fastft" data-vars-link-text="FastFT">FastFT</a>
-			</li>
-			<li class="o-header__nav-item">
 				<a class="o-header__nav-link o-header__nav-link--primary" href="http://markets.ft.com/data" data-vars-link-destination="http://markets.ft.com/data" data-vars-link-type="nav-marketsdata" data-vars-link-text="Markets Data">Markets Data</a>
 			</li>
 		</ul>


### PR DESCRIPTION
## Description
Remove link to FastFT since it's now defunct.
See https://financialtimes.slack.com/archives/C03TWD9G1/p1621870002027800

## Ticket
[NOPS-48](https://financialtimes.atlassian.net/browse/NOPS-48)