### PR TITLE
Master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -138,7 +138,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_master
+            <<: *filters_ignore_main
       - test:
           requires:
             - build
@@ -150,7 +150,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
       - test:
           requires:
             - build
@@ -163,7 +163,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 _extends: github-apps-config-next
 
 branches: 
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews: null
       required_status_checks:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "npm": "6.13.6"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^5.1.1",
+    "@financial-times/n-gage": "^8.2.0",
     "@financial-times/n-heroku-tools": "^12.1.0",
     "@financial-times/n-test": "^1.15.0",
     "@quarterto/chai-dom-equal": "^1.6.0",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # google-amp
 
-[![Circle CI](https://circleci.com/gh/Financial-Times/google-amp/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/google-amp/tree/master) [![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/google-amp/badge.svg)](https://snyk.io/test/github/Financial-Times/google-amp)
+[![Circle CI](https://circleci.com/gh/Financial-Times/google-amp/tree/main.svg?style=svg)](https://circleci.com/gh/Financial-Times/google-amp/tree/main) [![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/google-amp/badge.svg)](https://snyk.io/test/github/Financial-Times/google-amp)
 
 AMP HTML rendering for FT articles
 
@@ -49,7 +49,7 @@ A Day in the Life of an AMP Article
 Deployment
 ---
 
-The `master` branch deploys automatically to prod once the tests are green. Pull requests deploy to review apps, look out for the `@username deployed to google-amp-prod-eu-pr-XXX` messages in the PR.
+The `main` branch deploys automatically to prod once the tests are green. Pull requests deploy to review apps, look out for the `@username deployed to google-amp-prod-eu-pr-XXX` messages in the PR.
 
 ### Rolling back
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,12 @@
     "group:postcss",
     "group:linters"
   ],
-  "masterIssue": true,
   "packageRules": [
     {
       "depTypeList": [
         "devDependencies"
       ],
-      "masterIssueApproval": true
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/server/controllers/analytics-proxy.js
+++ b/server/controllers/analytics-proxy.js
@@ -21,7 +21,7 @@ module.exports = (req, res) => {
 
 	// Switch between JSON and image/gif depending on what the client sent
 	//
-	// https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md
+	// https://github.com/ampproject/amphtml/blob/main/extensions/amp-analytics/amp-analytics.md
 	// 		- beacon Indicates navigator.sendBeacon can be used to transmit
 	// 			the request. This will send a POST request, with credentials, and an empty body.
 	// 		- xhrpost Indicates XMLHttpRequest can be used to transmit the request.

--- a/server/lib/transforms/html/remove-invalid-links.js
+++ b/server/lib/transforms/html/remove-invalid-links.js
@@ -9,7 +9,7 @@ const validProtocols = [
 	'sms', 'tel', 'threema', 'viber', 'whatsapp',
 ];
 
-// See https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii
+// See https://github.com/ampproject/amphtml/blob/main/validator/validator-main.protoascii
 const validateHref = href => {
 	// AMP links must have an href
 	if(!href) {


### PR DESCRIPTION
bonus discovery that `masterIssue`  isn't a thing in renovate anymore, it's called `dependencyDashboard` as per the [release notes.](https://github.com/renovatebot/renovate/pull/6729/files)