### PR TITLE
Set fastly-client-ip on the edge

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -6,6 +6,13 @@ table origin_hosts {
 sub vcl_recv {
 #FASTLY recv
 
+	if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+		# fastly-client-ip is not protected from modification on the edge
+		# Prevent misuse by setting it ourselves
+		# https://developer.fastly.com/reference/http/http-headers/Fastly-Client-IP/
+		set req.http.Fastly-Client-IP = client.ip;
+	}
+
 	#
 	# Multi-region routing to serve requests from the nearest backend.
 	#


### PR DESCRIPTION
The value of fastly-client-ip is not protected from modification at the edge of the Fastly network,
so if a client sets this header themselves, it will be used.

To protect against this we set it ourselves.

https://developer.fastly.com/reference/http/http-headers/Fastly-Client-IP/

This service and app doesn't actually use this header at the moment but I am adding this protection just incase it is used in the future.