### PR TITLE
CI-976 Pin colors to v1.4.0 to avoid known vulnerability in colors v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "postcss-inline-svg": "^3.0.0",
     "postcss-remove-unused": "^1.2.0",
     "raven": "^0.12.0",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "colors": "1.4.0"
   },
   "engines": {
     "node": "12.x",


### PR DESCRIPTION
See https://response.ftops.tech/incident/1380/

on 8th Jan, v1.4.1 of colors.js was released, which deliberately causes an infinite loop when the package is used
this causes CircleCI builds for affected services to run indefinitely. Pinning colors to v1.4.0, which is the last known good version, circumvents the issue.

In the case of AMP colors is somewhere down in the dependency tree. Pinning the version in package.json installs the correct version and AMP continues to display correctly when run locally.

