### PR TITLE
move from legacy dataset available under geoip to the current dataset under client.geo

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -46,19 +46,19 @@ sub vcl_recv {
 	}
 
 	if (req.http.x-geoip-override) {
-		set geoip.ip_override = req.http.x-geoip-override;
+		set client.geo.ip_override = req.http.x-geoip-override;
 	}
 
 	if (!req.http.country-code) {
-		set req.http.country-code = geoip.country_code3;
+		set req.http.country-code = client.geo.country_code3;
 	}
 
 	if (!req.http.country-code-two-letters) {
-		set req.http.country-code-two-letters = geoip.country_code;
+		set req.http.country-code-two-letters = client.geo.country_code;
 	}
 
 	if (!req.http.continent_code) {
-		set req.http.continent_code = geoip.continent_code;
+		set req.http.continent_code = client.geo.continent_code;
 	}
 
 	if (!req.http.ft-allocation-id && req.http.Cookie ~ "(^|; *)FTAllocation=([^;]+).*$") {


### PR DESCRIPTION
The old dataset is looking to be retired soon - approximately May 2022

The data returned for a given IP address may be different between the current and legacy datasets, especially at the city level.
The other differences between the two datasets are:
    Results for IPv6 addresses are only returned in the new dataset.
    The datasets each have different formatting conventions. For example, `client.geo.city` and `client.geo.country_name` exist as lowercase ASCII values whereas the values returned for the same fields in the `geoip.` namespace are mixed case.
    The `client.geo.region` field contains ISO 3166-2 region codes but the `geoip.region` field contains FIPS10-4 region codes. 

More documentation about this can be found at https://developer.fastly.com/reference/vcl/variables/geolocation/