### PR TITLE
ADSDEV-1055 Create AMP re-direct

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@financial-times/fastly-tools": "^1.7.1",
     "@financial-times/n-es-client": "3.0.0",
+    "@financial-times/n-express": "^23.0.0",
     "@georgecrawford/postcss-remove-important": "^1.4.0",
     "@quarterto/assert-env": "^1.4.0",
     "@quarterto/assert-heroku-env": "^1.3.0",
@@ -38,6 +39,7 @@
     "@quarterto/tcp-fetch": "^1.0.0",
     "autoprefixer": "^6.3.3",
     "cheerio": "^0.22.0",
+    "colors": "1.4.0",
     "cookie-parser": "^1.4.1",
     "csso": "^3.0.0",
     "denodeify": "^1.2.1",
@@ -74,8 +76,7 @@
     "postcss-inline-svg": "^3.0.0",
     "postcss-remove-unused": "^1.2.0",
     "raven": "^0.12.0",
-    "supertest": "^4.0.2",
-    "colors": "1.4.0"
+    "supertest": "^4.0.2"
   },
   "engines": {
     "node": "12.x",

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -25,7 +25,7 @@ module.exports = async (req, res, next) => {
 
 		const flags = res.locals.flags;
 		if(flags && flags.redirectAmpPageTemp) {
-			return res.redirect(301, article.url);
+			return res.redirect(302, article.url);
 		}
 
 		if(skipArticle(article)) {

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -23,6 +23,11 @@ module.exports = async (req, res, next) => {
 			throw error;
 		});
 
+		const flags = res.locals.flags;
+		if(flags && flags.redirectAmpPageTemp) {
+			return res.redirect(301, article.url);
+		}
+
 		if(skipArticle(article)) {
 			return res.redirect(article.url);
 		}

--- a/server/controllers/amp-page.js
+++ b/server/controllers/amp-page.js
@@ -9,6 +9,17 @@ const reportError = require('../lib/report-error');
 
 module.exports = async (req, res, next) => {
 	try {
+		const flags = res.locals.flags;
+		if (flags && flags.redirectAmpPageTemp) {
+			const uuid = encodeURIComponent(req.params.uuid);
+			const uuidTest = new RegExp(/^[0-9a-f]{8}-?[0-9a-f]{4}-?[1-5][0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/i);
+			if (!uuidTest.test(uuid)) {
+				throw new errors.NotFound(`Article ${uuid} not found`);
+			}
+			const articleUrl = `https://www.ft.com/content/${uuid}`;
+			return res.redirect(302, articleUrl);
+		}
+
 		const article = await nEsClient.get(req.params.uuid).catch(error => {
 			if(error.status === 404) {
 				throw new errors.NotFound(`Article ${req.params.uuid} not found`);
@@ -22,11 +33,6 @@ module.exports = async (req, res, next) => {
 
 			throw error;
 		});
-
-		const flags = res.locals.flags;
-		if(flags && flags.redirectAmpPageTemp) {
-			return res.redirect(302, article.url);
-		}
 
 		if(skipArticle(article)) {
 			return res.redirect(article.url);

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const express = require('express');
+const express = require('@financial-times/n-express');
 const logger = require('morgan');
 const raven = require('raven');
 const cookieParser = require('cookie-parser');
@@ -14,7 +14,10 @@ const cors = require('./lib/cors');
 const handlebars = require('./lib/templating/handlebars');
 const pkg = require('../package.json');
 
-const app = express();
+const app = express({
+	systemCode: 'google-amp',
+	withFlags: true,
+});
 
 const isDevelopment = app.get('env') === 'development';
 const isProduction = app.get('env') === 'production';


### PR DESCRIPTION
## Feature Description

As a part of the plan to disable AMP on FT, this PR is to toggle the re-direct of AMP page requests based on a flag `redirectAmpPageTemp`. When the flag is on, instead of providing the AMP version of the content page, it sends a `302 Found` to redirect the request to the canonical FT.com page.